### PR TITLE
Fix: guard MergeIncoming against overwriting own data

### DIFF
--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -854,14 +854,21 @@ end
 -- Returns true if any data was merged.
 function Data:MergeIncoming(incomingData)
     local changed = false
+    local playerKey = self:GetPlayerKey()
     for memberKey, incomingEntry in pairs(incomingData) do
         if type(incomingEntry) == "table" and incomingEntry.lastUpdate then
-            local localEntry = self.db.global[memberKey]
-            if not localEntry or incomingEntry.lastUpdate > localEntry.lastUpdate then
-                -- Full replacement — handles profession removals correctly
-                self.db.global[memberKey] = incomingEntry
-                changed = true
-                GuildCrafts:Debug("Merged data for:", memberKey)
+            -- Never overwrite our own data — we're always authoritative
+            -- for ourselves (local scans have reagents/cooldowns that
+            -- sync payloads strip out)
+            if memberKey == playerKey then
+                GuildCrafts:Debug("Skipped merge for own data:", memberKey)
+            else
+                local localEntry = self.db.global[memberKey]
+                if not localEntry or incomingEntry.lastUpdate > localEntry.lastUpdate then
+                    self.db.global[memberKey] = incomingEntry
+                    changed = true
+                    GuildCrafts:Debug("Merged data for:", memberKey)
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary

- Skip own `memberKey` in `MergeIncoming` so stripped sync payloads never replace locally-scanned data that includes reagents and cooldowns

## Context

`StripSyncFields` removes `reagents` and `cooldowns` from outgoing sync data (correct — they're local-only). But `MergeIncoming` did full replacement when `incomingEntry.lastUpdate > localEntry.lastUpdate`, which could overwrite the local player's enriched data with a stripped version in edge cases (reset + re-sync, multi-boxing, clock skew).

The local player is always authoritative for their own entry, so we skip it entirely.

## Test plan

- [ ] `/gc sim sync` — verify own player data is not replaced (debug output should show "Skipped merge for own data")
- [ ] Open profession window after sync — reagents and cooldowns should still be present

🤖 Generated with [Claude Code](https://claude.com/claude-code)