### PR TITLE
Fix: testing bugfixes (staleness, sync, minimap, UI)

### DIFF
--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -140,6 +140,8 @@ function Comms:HandleHello(payload, sender)
     local memberKey = payload.sender or sender
     if not memberKey then return end
 
+    local isNew = not self.addonUsers[memberKey]
+
     self.addonUsers[memberKey] = {
         version  = payload.version or 1,
         lastSeen = time(),
@@ -147,6 +149,29 @@ function Comms:HandleHello(payload, sender)
 
     GuildCrafts:Debug("HELLO from", memberKey, "v" .. (payload.version or "?"))
     self:RecomputeElection()
+
+    -- Reply with our own HELLO so the sender discovers us too.
+    -- Only reply to genuinely new users (not replies) to prevent infinite loops.
+    if isNew and not payload.isReply then
+        local playerKey = GuildCrafts.Data:GetPlayerKey()
+        if memberKey ~= playerKey then
+            self:SendMessage(MSG_HELLO, {
+                sender  = playerKey,
+                version = GuildCrafts.VERSION,
+                isReply = true,
+            }, "GUILD")
+            GuildCrafts:Debug("Sent HELLO reply to", memberKey)
+        end
+    end
+
+    -- Trigger a sync whenever we discover a new addon user.
+    -- This handles late logins, reconnects, and the initial race where
+    -- the first SYNC_REQUEST fires before any HELLO replies arrive.
+    if isNew and not self.syncPending then
+        self.syncRetryCount = 0
+        self:ScheduleTimer("SendSyncRequest", 2)
+        GuildCrafts:Debug("Scheduling re-sync after discovering", memberKey)
+    end
 end
 
 ----------------------------------------------------------------------
@@ -360,8 +385,10 @@ function Comms:OnSyncTimeout()
     elseif self.syncRetryCount == 2 then
         -- Neither DR nor BDR responded — evict both and re-elect so the
         -- new DR (sorted[1] of remaining nodes) handles the request.
-        if self.currentDR  then self.addonUsers[self.currentDR]  = nil end
-        if self.currentBDR then self.addonUsers[self.currentBDR] = nil end
+        -- Never evict ourselves — we know we're online.
+        local playerKey = GuildCrafts.Data:GetPlayerKey()
+        if self.currentDR  and self.currentDR  ~= playerKey then self.addonUsers[self.currentDR]  = nil end
+        if self.currentBDR and self.currentBDR ~= playerKey then self.addonUsers[self.currentBDR] = nil end
         self:RecomputeElection()
         GuildCrafts:Debug("SYNC_REQUEST retry timeout — evicted DR/BDR, re-elected. New DR:", self.currentDR or "none")
         self:SendSyncRequest()
@@ -389,8 +416,10 @@ function Comms:HandleSyncRequest(payload, sender)
     elseif retryCount >= 2 then
         -- DR and BDR both failed to respond — evict them and re-elect.
         -- Only the newly elected DR responds, preventing a flood.
-        if self.currentDR  then self.addonUsers[self.currentDR]  = nil end
-        if self.currentBDR then self.addonUsers[self.currentBDR] = nil end
+        -- Never evict ourselves — we know we're online.
+        local playerKey = GuildCrafts.Data:GetPlayerKey()
+        if self.currentDR  and self.currentDR  ~= playerKey then self.addonUsers[self.currentDR]  = nil end
+        if self.currentBDR and self.currentBDR ~= playerKey then self.addonUsers[self.currentBDR] = nil end
         self:RecomputeElection()
         if self.myRole == "DR" then
             shouldRespond = true

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -478,7 +478,7 @@ end
 --- Check if a member's data is stale (not updated in 30+ days).
 --- Returns nil if fresh, or a human-readable age string if stale.
 function Data:GetStalenessTag(lastUpdate)
-    if not lastUpdate then return "unknown" end
+    if not lastUpdate or lastUpdate == 0 then return nil end
     local age = time() - lastUpdate
     if age < STALE_THRESHOLD then return nil end
 

--- a/GuildCrafts/MinimapButton.lua
+++ b/GuildCrafts/MinimapButton.lua
@@ -49,11 +49,35 @@ end
 -- Position Helpers
 ----------------------------------------------------------------------
 
+--- Detect whether the minimap is rendered as a square (e.g. SexyMap,
+--- BasicMinimap, or any addon that swaps the mask texture).
+local function IsMinimapRound()
+    if Minimap.GetMaskTexture then
+        local mask = Minimap:GetMaskTexture()
+        if mask and not mask:lower():find("minimapmask") then
+            return false
+        end
+    end
+    return true  -- default WoW minimap is round
+end
+
 local function UpdatePosition(btn, angle)
-    local x = math.cos(angle) * DRAG_RADIUS
-    local y = math.sin(angle) * DRAG_RADIUS
+    local x = math.cos(angle)
+    local y = math.sin(angle)
+
+    if not IsMinimapRound() then
+        -- Project the circular unit vector onto the square perimeter.
+        -- Dividing by max(|x|,|y|) scales the larger component to ±1,
+        -- keeping the angle identical but hugging the square edge.
+        local q = math.max(math.abs(x), math.abs(y))
+        if q > 0 then
+            x = x / q
+            y = y / q
+        end
+    end
+
     btn:ClearAllPoints()
-    btn:SetPoint("CENTER", Minimap, "CENTER", x, y)
+    btn:SetPoint("CENTER", Minimap, "CENTER", x * DRAG_RADIUS, y * DRAG_RADIUS)
 end
 
 local function AngleFromCursor()

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -442,7 +442,7 @@ function UI:PopulateProfessionList()
         yOffset = yOffset + 24
     end
 
-    self.leftContent:SetHeight(math.max(yOffset, 1))
+    self.leftContent:SetHeight(math.max(yOffset + 8, 1))
     self:UpdateDetailWelcome()
 end
 
@@ -501,7 +501,7 @@ function UI:NavigateToMembers(profName)
         yOffset = yOffset + 24
     end
 
-    self.leftContent:SetHeight(math.max(yOffset, 1))
+    self.leftContent:SetHeight(math.max(yOffset + 8, 1))
     self:UpdateDetailWelcome()
 end
 
@@ -663,7 +663,8 @@ function UI:ShowMemberRecipes(memberKey, profName)
             reagentText:SetWidth(360)
             self.detailRows[#self.detailRows + 1] = reagentText
             -- Measure actual height for wrapped text
-            local textHeight = reagentText:GetStringHeight() or 12
+            local textHeight = reagentText:GetStringHeight()
+            if not textHeight or textHeight < 12 then textHeight = 12 end
             yOffset = yOffset - 14 - textHeight - 4
         else
             yOffset = yOffset - 6
@@ -672,7 +673,7 @@ function UI:ShowMemberRecipes(memberKey, profName)
         yOffset = yOffset - 14
     end
 
-    self.detailContent:SetHeight(math.max(math.abs(yOffset), 1))
+    self.detailContent:SetHeight(math.max(math.abs(yOffset) + 8, 1))
 end
 
 ----------------------------------------------------------------------
@@ -765,7 +766,7 @@ function UI:ShowSearchResults(results)
         yOffset = yOffset - 8  -- spacing between recipes
     end
 
-    self.detailContent:SetHeight(math.max(math.abs(yOffset), 1))
+    self.detailContent:SetHeight(math.max(math.abs(yOffset) + 8, 1))
 end
 
 ----------------------------------------------------------------------
@@ -1048,7 +1049,7 @@ function UI:FilterProfessionList(query)
             yOffset = yOffset + 24
         end
     end
-    self.leftContent:SetHeight(math.max(yOffset, 1))
+    self.leftContent:SetHeight(math.max(yOffset + 8, 1))
 end
 
 function UI:FilterMemberList(query)
@@ -1082,7 +1083,7 @@ function UI:FilterMemberList(query)
         self.leftRows[#self.leftRows + 1] = row
         yOffset = yOffset + 24
     end
-    self.leftContent:SetHeight(math.max(yOffset, 1))
+    self.leftContent:SetHeight(math.max(yOffset + 8, 1))
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
## Bug fixes from live testing

### 1. Staleness "683mo ago" display (Data.lua)
- `GetStalenessTag` now returns `nil` for `lastUpdate == 0`
- New member entries default to `0`, which produced the full Unix epoch as months

### 2. Self-eviction -> Addon users: 0 (Comms.lua)
- Solo user is DR; on sync retry 2, code evicted DR from `addonUsers` — evicting yourself
- Now guards against evicting `playerKey`

### 3. One-way HELLO -> peers invisible (Comms.lua)
- HELLO was broadcast-only with no reply; late-joining users never discovered existing users
- `HandleHello` now replies with own HELLO (`isReply = true` to prevent loops)

### 4. Sync not triggered after discovery (Comms.lua)
- Initial `SYNC_REQUEST` fires before HELLO replies arrive -> no DR to respond
- Now schedules a re-sync 2s after discovering any new addon user via HELLO

### 5. UI scroll clipping (MainFrame.lua)
- Last row in both panels could clip below the scroll area
- Added 8px bottom padding to all content height calculations
- Guarded `GetStringHeight()` returning nil/0 for wrapped reagent text

### 6. Minimap button on square minimaps (MinimapButton.lua)
- Button orbited in a circle even on square minimaps (SexyMap, BasicMinimap, etc.)
- Detects square minimap via `GetMaskTexture()` and projects position onto square perimeter
