### PR TITLE
Fix: backfill lastUpdate bump, refresh bleed-through, reagents in sync, login reminder

### DIFF
--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -86,6 +86,9 @@ function GuildCrafts:OnLoginReady()
     if self.Comms then
         self.Comms:OnLoginReady()
     end
+
+    -- Remind the player to open profession windows so recipes get scanned
+    self:Print("Open each profession window once so GuildCrafts can scan your recipes.")
 end
 
 function GuildCrafts:OnTradeSkillShow()

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -542,6 +542,7 @@ function Data:ScanTradeSkill()
     local newCount = 0
     local newRecipes = {}
     local currentCategory = nil
+    local backfillChanged = false
 
     for i = 1, numSkills do
         local skillName, skillType = GetTradeSkillInfo(i)
@@ -564,14 +565,21 @@ function Data:ScanTradeSkill()
                     if not recipes[recipeKey].reagents then
                         -- Backfill reagent data for recipes scanned before reagent tracking
                         recipes[recipeKey].reagents = self:ScanTradeSkillReagents(i)
+                        backfillChanged = true
                     end
                     if not recipes[recipeKey].category and currentCategory then
                         -- Backfill category for recipes scanned before categorization
                         recipes[recipeKey].category = currentCategory
+                        backfillChanged = true
                     end
                 end
             end
         end
+    end
+
+    if backfillChanged and newCount == 0 then
+        entry.lastUpdate = time()
+        GuildCrafts:Printf("Scanned %s: backfilled reagent/category data.", profName)
     end
 
     if newCount > 0 then
@@ -690,6 +698,7 @@ function Data:ScanCraft()
     local newCount = 0
     local newRecipes = {}
     local currentCategory = nil
+    local backfillChanged = false
 
     for i = 1, numCrafts do
         local craftName, _, craftType = GetCraftInfo(i)
@@ -712,14 +721,21 @@ function Data:ScanCraft()
                     if not recipes[recipeKey].reagents then
                         -- Backfill reagent data for recipes scanned before reagent tracking
                         recipes[recipeKey].reagents = self:ScanCraftReagents(i)
+                        backfillChanged = true
                     end
                     if not recipes[recipeKey].category and currentCategory then
                         -- Backfill category for recipes scanned before categorization
                         recipes[recipeKey].category = currentCategory
+                        backfillChanged = true
                     end
                 end
             end
         end
+    end
+
+    if backfillChanged and newCount == 0 then
+        entry.lastUpdate = time()
+        GuildCrafts:Printf("Scanned %s: backfilled reagent/category data.", profName)
     end
 
     if newCount > 0 then
@@ -807,7 +823,7 @@ function Data:StripSyncFields(entry)
                 name = recipeData.name,
                 source = recipeData.source,
                 category = recipeData.category,
-                -- reagents intentionally omitted
+                reagents = recipeData.reagents,
             }
         end
         copy.professions[profName] = profCopy
@@ -826,6 +842,7 @@ function Data:StripRecipeReagents(recipes)
             name = recipeData.name,
             source = recipeData.source,
             category = recipeData.category,
+            reagents = recipeData.reagents,
         }
     end
     return copy

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -1112,6 +1112,10 @@ end
 ----------------------------------------------------------------------
 
 function UI:UpdateDetailWelcome()
+    -- During a Refresh cycle, skip — Refresh will call us at the end
+    -- with the correct state to avoid flashing the welcome text.
+    if self._refreshing then return end
+
     if self._selectedMember or self._searchActive then
         self.detailWelcome:Hide()
     else
@@ -1285,16 +1289,33 @@ function UI:Refresh()
 
     self:UpdateSyncIndicator()
 
+    -- Save state that will be cleared by NavigateToMembers/PopulateProfessionList
+    local savedMember = self._selectedMember
+    local savedSearch = self._searchActive
+
+    -- Suppress intermediate UpdateDetailWelcome calls during refresh
+    -- to prevent the welcome text from flashing over content.
+    self._refreshing = true
+
     if self._navState == "professions" then
         self:PopulateProfessionList()
     elseif self._navState == "members" and self._selectedProfession then
         self:NavigateToMembers(self._selectedProfession)
     end
 
+    self._refreshing = false
+
+    -- Restore state cleared by the left-panel rebuild
+    self._selectedMember = savedMember
+    self._searchActive = savedSearch
+
     -- Refresh detail if a member was selected
     if self._selectedMember and self._selectedProfession then
         self:ShowMemberRecipes(self._selectedMember, self._selectedProfession)
     end
+
+    -- Make sure welcome state is correct after all updates
+    self:UpdateDetailWelcome()
 
     self:RefreshCraftQueue()
 end


### PR DESCRIPTION
## Changes

- **Welcome text bleed-through on Refresh**: Added `_refreshing` flag to suppress intermediate `UpdateDetailWelcome` calls; save/restore `_selectedMember` and `_searchActive` across refresh
- **Include reagents in sync data**: `StripSyncFields` and `StripRecipeReagents` now include `reagents` in the data sent over the wire
- **Bump lastUpdate on backfill**: When `ScanTradeSkill` or `ScanCraft` backfills reagent/category data onto existing recipes, `lastUpdate` is now bumped so the next sync picks up the changes (fixes "already converged" with stale data)
- **Login reminder**: Chat message on login reminding players to open each profession window once for scanning