### PR TITLE
Fix: data format version resync, craft request popup fixes

### DIFF
--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -480,6 +480,14 @@ function Comms:ProcessSyncRequest(requester, incomingVector)
         if not localTs or incomingTs > localTs then
             -- Requester has newer data → request via SYNC_PULL
             toPull[#toPull + 1] = memberKey
+        elseif localTs == incomingTs then
+            -- Timestamps match — check if our local copy is in an old data format
+            local localEntry = db[memberKey]
+            if localEntry and (localEntry.dataFormat or 0) < GuildCrafts.DATA_FORMAT_VERSION then
+                toPull[#toPull + 1] = memberKey
+                GuildCrafts:Debug("Format upgrade pull for", memberKey,
+                    "(local format", localEntry.dataFormat or 0, "< current", GuildCrafts.DATA_FORMAT_VERSION, ")")
+            end
         end
     end
 

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -19,6 +19,10 @@ _G.GuildCrafts = GuildCrafts
 GuildCrafts.VERSION = 1
 GuildCrafts.ADDON_PREFIX = "GuildCrafts"
 
+-- Data format version — bump when sync payload structure changes
+-- (e.g. adding reagents to sync). Forces re-pull of stale copies.
+GuildCrafts.DATA_FORMAT_VERSION = 2
+
 -- Debug mode toggle
 GuildCrafts.debugMode = false
 

--- a/GuildCrafts/CraftRequest.lua
+++ b/GuildCrafts/CraftRequest.lua
@@ -54,11 +54,6 @@ function CraftRequest:OnIncomingRequest(requester, itemName)
     GuildCrafts:Printf("|cffffd100Craft Request:|r %s wants you to craft: |cffffd100%s|r",
         requester, itemName)
 
-    -- Play alert sound
-    if PlaySound then
-        PlaySound(SOUNDKIT and SOUNDKIT.READY_CHECK or 8960)
-    end
-
     -- Add to pending popups
     local request = {
         requester = requester,
@@ -67,9 +62,34 @@ function CraftRequest:OnIncomingRequest(requester, itemName)
     }
     self.pendingPopups[#self.pendingPopups + 1] = request
 
+    -- Defer popup if in combat
+    if InCombatLockdown() or UnitAffectingCombat("player") then
+        GuildCrafts:Debug("Deferring craft request popup (in combat)")
+        if not self._combatDeferred then
+            self._combatDeferred = true
+            GuildCrafts:RegisterEvent("PLAYER_REGEN_ENABLED", function()
+                GuildCrafts:UnregisterEvent("PLAYER_REGEN_ENABLED")
+                self._combatDeferred = false
+                self:ShowDeferredPopups()
+            end)
+        end
+        return
+    end
+
     -- Show popup UI
     if GuildCrafts.UI and GuildCrafts.UI.ShowCraftRequestPopup then
         GuildCrafts.UI:ShowCraftRequestPopup(request)
+    end
+end
+
+function CraftRequest:ShowDeferredPopups()
+    for _, request in ipairs(self.pendingPopups) do
+        if not request._popupShown then
+            request._popupShown = true
+            if GuildCrafts.UI and GuildCrafts.UI.ShowCraftRequestPopup then
+                GuildCrafts.UI:ShowCraftRequestPopup(request)
+            end
+        end
     end
 end
 

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -806,6 +806,7 @@ function Data:StripSyncFields(entry)
 
     local copy = {
         lastUpdate = entry.lastUpdate,
+        dataFormat = GuildCrafts.DATA_FORMAT_VERSION,
         _simulated = entry._simulated,
         professions = {},
     }
@@ -881,7 +882,11 @@ function Data:MergeIncoming(incomingData)
                 GuildCrafts:Debug("Skipped merge for own data:", memberKey)
             else
                 local localEntry = self.db.global[memberKey]
-                if not localEntry or incomingEntry.lastUpdate > localEntry.lastUpdate then
+                local dominated = not localEntry
+                    or incomingEntry.lastUpdate > localEntry.lastUpdate
+                    or (incomingEntry.lastUpdate == localEntry.lastUpdate
+                        and (incomingEntry.dataFormat or 0) > (localEntry.dataFormat or 0))
+                if dominated then
                     self.db.global[memberKey] = incomingEntry
                     changed = true
                     GuildCrafts:Debug("Merged data for:", memberKey)

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -865,26 +865,27 @@ function UI:ShowCraftRequestPopup(request)
     declineText:SetText("Decline")
     declineText:SetTextColor(1, 0.8, 0.8)
 
-    -- Handlers
+    -- Handlers — hide popup FIRST to ensure it disappears even if
+    -- downstream logic (queue refresh, comms) throws an error.
     accept:SetScript("OnClick", function()
+        self:RemovePopup(popup)
         if GuildCrafts.CraftRequest then
             GuildCrafts.CraftRequest:AcceptRequest(request)
         end
-        self:RemovePopup(popup)
     end)
 
     decline:SetScript("OnClick", function()
+        self:RemovePopup(popup)
         if GuildCrafts.CraftRequest then
             GuildCrafts.CraftRequest:DeclineRequest(request)
         end
-        self:RemovePopup(popup)
     end)
 
     closeBtn:SetScript("OnClick", function()
+        self:RemovePopup(popup)
         if GuildCrafts.CraftRequest then
             GuildCrafts.CraftRequest:DeclineRequest(request)
         end
-        self:RemovePopup(popup)
     end)
 
     -- Track popup


### PR DESCRIPTION
## Changes

- **DATA_FORMAT_VERSION re-sync**: Added `DATA_FORMAT_VERSION = 2` to force re-pull of synced copies missing fields added in newer formats (e.g. reagents). Fixes "already converged" with stale data.
- **Backfill lastUpdate bump**: `ScanTradeSkill` and `ScanCraft` now bump `lastUpdate` when backfilling reagent/category data onto existing recipes.
- **Login reminder**: Chat message on login reminding players to open each profession window.
- **Craft request popup dismiss**: `RemovePopup` now runs before downstream logic so the popup always hides.
- **Combat suppression**: Craft request popups are deferred until combat ends.
- **No popup sound**: Removed `PlaySound` from craft request popups.