### PR TITLE
Chore: remove LibDeflate/.git, ignore zip artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Thumbs.db
 
 # WoW SavedVariables (generated at runtime)
 SavedVariables/
+
+# Build artifacts
+*.zip


### PR DESCRIPTION
Removes nested .git directory from LibDeflate (causes CurseForge rejection) and adds *.zip to .gitignore.