### PR TITLE
chore: set version to 1.0.4

### DIFF
--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -920,8 +920,8 @@ function Comms:ProcessIncoming(message, distribution, sender)
         if not self._versionWarned then self._versionWarned = {} end
         if not self._versionWarned[sender] then
             self._versionWarned[sender] = true
-            GuildCrafts:Printf("|cffff8800%s is running a newer GuildCrafts version (v%d). Please update.|r",
-                sender, msgVersion)
+            GuildCrafts:Printf("|cffff8800%s is running a newer GuildCrafts version. Please update.|r",
+                sender)
         end
         -- Still attempt to process — forward compatible where possible
     end

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -15,8 +15,12 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 -- Make it globally accessible for other files
 _G.GuildCrafts = GuildCrafts
 
--- Addon version (parsed from .toc at runtime, fallback to hardcoded)
-GuildCrafts.VERSION = 1
+-- Addon version — keep in sync with .toc and CurseForge
+GuildCrafts.DISPLAY_VERSION = "1.0.4"
+
+-- Protocol version — integer used in sync envelope for compatibility checks.
+-- Bump when the wire format changes in a backward-incompatible way.
+GuildCrafts.VERSION = 2
 GuildCrafts.ADDON_PREFIX = "GuildCrafts"
 
 -- Data format version — bump when sync payload structure changes
@@ -35,7 +39,7 @@ function GuildCrafts:OnInitialize()
     -- Set up database, register slash commands.
     self:RegisterChatCommand("gc", "SlashHandler")
     local clientInterface = select(4, GetBuildInfo()) or "unknown"
-    self:Print("v" .. self.VERSION .. " loaded (client Interface: " .. clientInterface .. "). Type /gc to open.")
+    self:Print("v" .. self.DISPLAY_VERSION .. " loaded (client Interface: " .. clientInterface .. "). Type /gc to open.")
 end
 
 function GuildCrafts:OnEnable()

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 0.1.0-dev
+## Version: 1.0.4
 ## SavedVariables: GuildCraftsDB
 ## X-Category: Guild
 


### PR DESCRIPTION
Set DISPLAY_VERSION and .toc to 1.0.4 to match CurseForge release. Keep VERSION as numeric protocol version for sync envelope compatibility.