### PR TITLE
chore: luacheck cleanup — 0 warnings / 0 errors

### DIFF
--- a/GuildCrafts/.luacheckrc
+++ b/GuildCrafts/.luacheckrc
@@ -2,15 +2,32 @@
 std = "lua51"
 max_line_length = false
 
+-- Exclude vendored libraries
+exclude_files = {
+    "Libs/**",
+}
+
+-- Suppress WoW-convention noise:
+--   unused self    — WoW callbacks always receive self
+--   self shadowing — SetScript handlers shadow the outer self
+ignore = {
+    "212/self",   -- unused argument 'self'
+    "432/self",   -- shadowing upvalue argument 'self'
+}
+
 globals = {
     "GuildCrafts",
     "GuildCraftsDB",
+    -- Slash commands
+    "SlashCmdList",
+    "SLASH_GUILDCRAFTS1",
+    "SLASH_GUILDCRAFTS2",
 }
 
 read_globals = {
     -- WoW API — Frames & UI
     "CreateFrame", "UIParent", "GameTooltip", "ItemRefTooltip",
-    "GameFontNormal",
+    "GameFontNormal", "GameFontHighlight", "GameFontHighlightSmall",
     "GameFontNormalLarge", "GameFontNormalSmall", "GameFontDisableSmall",
     "ChatFontNormal", "UISpecialFrames",
     "UIDropDownMenu_Initialize", "UIDropDownMenu_AddButton",
@@ -37,7 +54,11 @@ read_globals = {
     "GetNumSkillLines", "GetSkillLineInfo",
 
     -- WoW API — Guild
-    "GetGuildRosterInfo", "GetNumGuildMembers", "GuildRoster", "IsInGuild",
+    "GetGuildInfo", "GetGuildRosterInfo", "GetNumGuildMembers",
+    "GuildRoster", "IsInGuild",
+
+    -- WoW API — Combat
+    "InCombatLockdown", "UnitAffectingCombat",
 
     -- WoW API — Chat
     "SendChatMessage",

--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -4,7 +4,7 @@
 -- SYNC_REQUEST / SYNC_RESPONSE / SYNC_PULL / SYNC_PUSH,
 -- DELTA_UPDATE, CRAFT_* messages
 ----------------------------------------------------------------------
-local ADDON_NAME = "GuildCrafts"
+local _, _ns = ... -- luacheck: ignore (WoW addon bootstrap)
 local GuildCrafts = _G.GuildCrafts
 
 -- Create the Comms module (AceComm mixin for send/receive)
@@ -23,7 +23,6 @@ local pairs = pairs
 local ipairs = ipairs
 local type = type
 local table_sort = table.sort
-local table_concat = table.concat
 
 ----------------------------------------------------------------------
 -- Constants
@@ -43,7 +42,6 @@ local SYNC_CHUNK_SIZE      = 10      -- max members per sync chunk
 -- ChatThrottleLib priorities
 local PRIO_BULK   = "BULK"
 local PRIO_NORMAL = "NORMAL"
-local PRIO_ALERT  = "ALERT"
 
 -- Message types
 local MSG_HELLO              = "HELLO"
@@ -432,7 +430,6 @@ function Comms:HandleSyncRequest(payload, sender)
         -- DR and BDR both failed to respond — evict them and re-elect.
         -- Only the newly elected DR responds, preventing a flood.
         -- Never evict ourselves — we know we're online.
-        local playerKey = GuildCrafts.Data:GetPlayerKey()
         if self.currentDR  and self.currentDR  ~= playerKey then self.addonUsers[self.currentDR]  = nil end
         if self.currentBDR and self.currentBDR ~= playerKey then self.addonUsers[self.currentBDR] = nil end
         self:RecomputeElection()
@@ -748,7 +745,7 @@ function Comms:SendCraftComplete(requesterKey, itemName)
     }, "WHISPER", requesterKey, PRIO_NORMAL)
 end
 
-function Comms:HandleCraftRequest(payload, sender)
+function Comms:HandleCraftRequest(payload, _sender)
     GuildCrafts:Debug("CRAFT_REQUEST from", payload.requester, "for", payload.item)
     if GuildCrafts.CraftRequest and GuildCrafts.CraftRequest.OnIncomingRequest then
         GuildCrafts.CraftRequest:OnIncomingRequest(payload.requester, payload.item)
@@ -862,7 +859,7 @@ function Comms:OnCommReceived(prefix, message, distribution, sender)
     end
 end
 
-function Comms:ProcessIncoming(message, distribution, sender)
+function Comms:ProcessIncoming(message, _distribution, sender)
     -- Decompress if needed
     local flag = message:sub(1, 1)
     local data = message:sub(2)

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -60,7 +60,7 @@ end
 -- Event Handlers
 ----------------------------------------------------------------------
 
-function GuildCrafts:OnPlayerEnteringWorld(event, isLogin, isReload)
+function GuildCrafts:OnPlayerEnteringWorld(_event, isLogin, isReload)
     if not IsInGuild() then
         self:Debug("Not in a guild — sync disabled.")
         return

--- a/GuildCrafts/CraftRequest.lua
+++ b/GuildCrafts/CraftRequest.lua
@@ -3,14 +3,13 @@
 -- Craft request/queue management: popup handling, queue persistence,
 -- accept/decline/complete logic
 ----------------------------------------------------------------------
-local ADDON_NAME = "GuildCrafts"
+local _, _ns = ... -- luacheck: ignore (WoW addon bootstrap)
 local GuildCrafts = _G.GuildCrafts
 
 local CraftRequest = GuildCrafts:NewModule("CraftRequest", "AceTimer-3.0")
 GuildCrafts.CraftRequest = CraftRequest
 
 local time = time
-local pairs = pairs
 
 ----------------------------------------------------------------------
 -- Lifecycle

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -3,7 +3,7 @@
 -- SavedVariables management, recipe scanning, data merging,
 -- guild roster pruning, and simulation mode
 ----------------------------------------------------------------------
-local ADDON_NAME = "GuildCrafts"
+local _, _ns = ... -- luacheck: ignore (WoW addon bootstrap)
 local GuildCrafts = _G.GuildCrafts
 
 -- Create the Data module
@@ -438,8 +438,7 @@ function Data:ScanTradeSkillCooldowns(profName, numSkills)
     end
 
     -- Only update if cooldown state actually changed
-    local hasCD = false
-    for _ in pairs(cooldowns) do hasCD = true; break end
+    local hasCD = (next(cooldowns) ~= nil)
 
     local hadCD = profData.cooldowns ~= nil
     local changed = false
@@ -493,8 +492,7 @@ function Data:ScanCraftCooldowns(profName, numCrafts)
         end
     end
 
-    local hasCD = false
-    for _ in pairs(cooldowns) do hasCD = true; break end
+    local hasCD = (next(cooldowns) ~= nil)
 
     local hadCD = profData.cooldowns ~= nil
     local changed = false
@@ -1093,7 +1091,7 @@ function Data:DumpSummary()
         if type(entry) == "table" and entry.professions then
             totalMembers = totalMembers + 1
             local memberRecipes = 0
-            for profName, profData in pairs(entry.professions) do
+            for _, profData in pairs(entry.professions) do
                 if profData.recipes then
                     for _ in pairs(profData.recipes) do
                         memberRecipes = memberRecipes + 1
@@ -1340,7 +1338,8 @@ function Data:SimDelta()
     if not gdb then return end
     for memberKey, entry in pairs(gdb) do
         if type(entry) == "table" and entry._simulated then
-            for profName, profData in pairs(entry.professions) do
+            local profName = next(entry.professions)
+            if profName then
                 local newKey = 99000 + math.random(1, 9999)
                 local recipe = {
                     name = SAMPLE_RECIPES[math.random(#SAMPLE_RECIPES)] .. " (NEW)",

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -3,7 +3,7 @@
 -- Main window: title bar, two-panel split, sync indicator,
 -- resize, drag, ESC-to-close
 ----------------------------------------------------------------------
-local ADDON_NAME = "GuildCrafts"
+local _, _ns = ... -- luacheck: ignore (WoW addon bootstrap)
 local GuildCrafts = _G.GuildCrafts
 
 -- UI namespace
@@ -1126,7 +1126,7 @@ function UI:UpdateDetailWelcome()
     end
 end
 
-function UI:ShowDetailEmpty(memberKey, profName)
+function UI:ShowDetailEmpty(_memberKey, _profName)
     self:ClearDetailRows()
     self.detailWelcome:Hide()
 


### PR DESCRIPTION
Clean up all 18 luacheck warnings across 6 source files. No functional changes.

- Replace unused `ADDON_NAME` with idiomatic `local _, _ns = ...`
- Remove dead locals (`table_concat`, `PRIO_ALERT`, `pairs`)
- Remove shadowed `playerKey` redeclaration in `Comms:HandleSyncRequest`
- Replace `for _ in pairs(t) do break end` with `next()` idiom
- Prefix unused callback args with `_` (WoW API signatures)
- Update `.luacheckrc`: add missing `read_globals`, suppress `self` noise