### PR TITLE
docs: update ROADMAP - #5 done, #10 moved to MarketCrafts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,10 +15,10 @@ Issue tracker: https://github.com/dkruenbo/GuildCrafts/issues
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| [#18](https://github.com/dkruenbo/GuildCrafts/issues/18) | Deduplicate reagent data with shared RecipeDB lookup | In progress (on release/1.1.0) |
+| [#18](https://github.com/dkruenbo/GuildCrafts/issues/18) | Deduplicate reagent data with shared RecipeDB lookup | Done in 1.1.0 |
 | [#19](https://github.com/dkruenbo/GuildCrafts/issues/19) | Incremental sync: send only changed professions | Not started |
-| [#20](https://github.com/dkruenbo/GuildCrafts/issues/20) | Auto-prune stale member entries | In progress (on release/1.1.0) |
-| [#5](https://github.com/dkruenbo/GuildCrafts/issues/5) | Favorites / Bookmarks | Not started |
+| [#20](https://github.com/dkruenbo/GuildCrafts/issues/20) | Auto-prune stale member entries | Done in 1.1.0 |
+| [#5](https://github.com/dkruenbo/GuildCrafts/issues/5) | Favorites / Bookmarks | Done in 1.1.0 |
 
 ## 1.2.0 — Network Efficiency
 
@@ -35,4 +35,4 @@ Issue tracker: https://github.com/dkruenbo/GuildCrafts/issues
 | [#9](https://github.com/dkruenbo/GuildCrafts/issues/9) | Code Modularisation | Not started |
 | [#7](https://github.com/dkruenbo/GuildCrafts/issues/7) | Export to CSV / Text | Not started |
 | [#8](https://github.com/dkruenbo/GuildCrafts/issues/8) | Locale Support | Not started |
-| [#10](https://github.com/dkruenbo/GuildCrafts/issues/10) | Craft Marketplace | Not started |
+| [#10](https://github.com/dkruenbo/GuildCrafts/issues/10) | Craft Marketplace | **Moved to separate addon: MarketCrafts** |


### PR DESCRIPTION
Updates ROADMAP.md to reflect completed work in 1.1.0:

- Mark #18 (Deduplicate reagent data with shared RecipeDB lookup) as Done in 1.1.0
- Mark #20 (Auto-prune stale member entries) as Done in 1.1.0
- Mark #5 (Favorites/Bookmarks) as Done in 1.1.0
- Mark #10 (Craft Marketplace) as **Moved to separate addon: MarketCrafts**