### PR TITLE
docs: clarify 1.1.0 issues are ready but not yet released

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,10 +15,10 @@ Issue tracker: https://github.com/dkruenbo/GuildCrafts/issues
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| [#18](https://github.com/dkruenbo/GuildCrafts/issues/18) | Deduplicate reagent data with shared RecipeDB lookup | Done in 1.1.0 |
+| [#18](https://github.com/dkruenbo/GuildCrafts/issues/18) | Deduplicate reagent data with shared RecipeDB lookup | Ready for 1.1.0 release |
 | [#19](https://github.com/dkruenbo/GuildCrafts/issues/19) | Incremental sync: send only changed professions | Not started |
-| [#20](https://github.com/dkruenbo/GuildCrafts/issues/20) | Auto-prune stale member entries | Done in 1.1.0 |
-| [#5](https://github.com/dkruenbo/GuildCrafts/issues/5) | Favorites / Bookmarks | Done in 1.1.0 |
+| [#20](https://github.com/dkruenbo/GuildCrafts/issues/20) | Auto-prune stale member entries | Ready for 1.1.0 release |
+| [#5](https://github.com/dkruenbo/GuildCrafts/issues/5) | Favorites / Bookmarks | Ready for 1.1.0 release |
 
 ## 1.2.0 — Network Efficiency
 


### PR DESCRIPTION
Changed status from 'Done in 1.1.0' to 'Ready for 1.1.0 release' for #18, #20, and #5 since 1.1.0 hasn't been shipped yet.