### PR TITLE
fix: hunter pet abilities no longer tracked as Enchanting recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 - **Expand icons on non-TBC fonts**: Unicode arrow characters (`►`/`▼`) are not present in all TBC client fonts and were rendering as rectangles. Replaced with ASCII `+`/`-`.
 
+- **Hunter pet abilities tracked as Enchanting recipes**: In Classic TBC, `CRAFT_SHOW` fires for both the Enchanting window and the Beast Training (hunter pet) window. `ScanCraft` was unconditionally assigning all scanned entries to "Enchanting", causing pet abilities (Claw, Dash, Dive, etc.) to appear as Enchanting recipes for hunter characters. Fixed by (1) checking that the player has the Enchanting skill line before scanning and aborting early if not, and (2) skipping any entry whose `craftType == "ability"` as a secondary guard for the Enchanter+Hunter edge case. The same `craftType` guard was applied to `ScanCraftCooldowns`.
+
 ## 1.1.0 — 2026-02-27
 
 ### Features

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -570,7 +570,7 @@ function Data:ScanCraftCooldowns(profName, numCrafts)
 
     for i = 1, numCrafts do
         local craftName, _, craftType = GetCraftInfo(i)
-        if craftType ~= "header" and craftName then
+        if craftType ~= "header" and craftType ~= "ability" and craftName then
             local cdRemaining = GetCraftCooldown(i)
             if cdRemaining and cdRemaining > 0 then
                 cooldowns[craftName] = {
@@ -819,6 +819,21 @@ function Data:ScanCraft()
         return
     end
 
+    -- Guard: CRAFT_SHOW fires for both Enchanting and Beast Training (hunter pet)
+    -- windows in Classic TBC. Only scan when the player actually has Enchanting.
+    local hasEnchanting = false
+    for i = 1, GetNumSkillLines() do
+        local skillName, isHeader = GetSkillLineInfo(i)
+        if not isHeader and skillName == "Enchanting" then
+            hasEnchanting = true
+            break
+        end
+    end
+    if not hasEnchanting then
+        GuildCrafts:Debug("CRAFT_SHOW fired but player has no Enchanting skill — skipping scan (likely Beast Training).")
+        return
+    end
+
     local profName = "Enchanting"
     local playerKey = self:GetPlayerKey()
     local entry = self:GetMemberEntry(playerKey, true)
@@ -862,7 +877,9 @@ function Data:ScanCraft()
         local craftName, _, craftType = GetCraftInfo(i)
         if craftType == "header" then
             currentCategory = craftName
-        elseif craftName then
+        elseif craftName and craftType ~= "ability" then
+            -- Skip "ability" type entries (hunter pet abilities) as a secondary
+            -- guard in case an Enchanter+Hunter opens the Beast Training window.
             local recipeKey = self:GetCraftRecipeKey(i)
             if recipeKey then
                 -- Store/update reagents + category in shared RecipeDB


### PR DESCRIPTION
## Problem

In Classic TBC, `CRAFT_SHOW` fires for both the Enchanting window **and** the Beast Training (hunter pet) window. `ScanCraft` hardcoded `profName = "Enchanting"`, so pet abilities (Claw, Dash, Dive, Cobra Reflexes, etc.) were being stored as Enchanting recipes for any hunter character.

## Fix

**`GuildCrafts/Data.lua` — `ScanCraft`**
1. **Primary guard**: Before scanning, check that the player has the Enchanting skill line. Return early if not — covers all non-Enchanters (hunters, warriors, etc.).
2. **Secondary guard**: Skip entries where `craftType == "ability"` inside the scan loop, as a belt-and-suspenders guard for the rare Enchanter+Hunter who opens Beast Training.

**`GuildCrafts/Data.lua` — `ScanCraftCooldowns`**
3. Apply the same `craftType ~= "ability"` guard to the cooldown scan loop.

**`CHANGELOG.md`**
4. Bug fix documented under the 1.1.5 section.