### PR TITLE
v1.1.5b — addon user count, sync race, zombie users, MergeRealmlessKeys back-fill, HELLO jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.1.5b — 2026-03-03
+
+### Bug Fixes
+
+- **Duplicate members in profession list with empty recipes**: The same character could appear twice in the member list — once under a legacy key without realm suffix (e.g. `"RandomChar"`) and once under the current canonical form (`"RandomChar-Realmname"`). Clicking the legacy row showed an empty recipe panel. Fixed with a one-time `MergeRealmlessKeys` migration that runs on login: if only the realmless key exists it is renamed in-place; if both exist the newer entry (by `lastUpdate`) wins, any professions unique to the older entry are back-filled, and the duplicate is deleted. As a secondary guard, `GetMembersByProfession`, `GetProfessionMemberCount`, `GetAllRecipesForProfession`, and `SearchRecipes` now deduplicate by character name so stale DB copies never surface in the UI.
+
+- **`MergeRealmlessKeys` back-fill data loss**: If the canonical (`Name-Realm`) entry already contained a profession record (e.g. created by `DetectProfessions` with a newer timestamp but no recipes yet scanned), the back-fill skipped that profession entirely because it already existed in the winner. Any recipes stored in the legacy realmless entry for that profession were silently discarded. Fixed by merging at the individual recipe level: if a profession already exists in the winner, missing recipes from the loser are copied in one by one rather than skipping the whole block.
+
+- **HELLO reply thundering herd**: When a `discover=true` HELLO was broadcast to a large guild, all clients would reply simultaneously, potentially flooding the guild channel. Replies are now sent after a random jitter delay of 0.5–4.0 seconds, spreading the load evenly across the window.
+
+- **Addon user count inaccurate (sync dot tooltip)**: Multiple compounding issues caused the displayed count to be wrong in both directions.
+  - *Too low on login (stuck at 2)*: (a) A race between HELLO broadcast (T+8 s) and the first `SYNC_REQUEST` (T+10 s) meant HELLO replies from other nodes often hadn't arrived yet, causing a false DR self-election and a skipped sync. `RecomputeElection` now schedules a fresh sync whenever a demotion from DR → non-DR is detected. (b) After the correct DR was found, nodes whose HELLO reply was throttled or arrived late stayed invisible. A post-sync `discover` HELLO is now broadcast 5 s after sync completes; all online addon users reply unconditionally, populating the list within ~15 s of login. (c) `SYNC_REQUEST`, `SYNC_RESPONSE`, and `DELTA_UPDATE` messages opportunistically add the sender to `addonUsers` even if their HELLO was never received. (d) `OnGuildRosterUpdate` was evicting users whose `isOnline` flag was momentarily false during the unreliable login window — roster-based eviction removed entirely.
+  - *Too high over time (zombie users)*: Non-DR users are never expired by the DR heartbeat watchdog (only the DR node itself is watched), so logged-off users accumulated in `addonUsers` indefinitely. The table intentionally retains all discovered keys for fast reconnect, but the displayed count and `GetSyncStatus` now use `GetActiveAddonUserCount()`, which cross-checks `addonUsers` against the guild roster `_onlineCache`. Only the local player and roster-confirmed online users are counted.
+
+## 1.1.5a - hunter-pet-abilities-enchanting - 2026-03-03
+
+### Bug Fixes
+
+- **Hunter pet abilities tracked as Enchanting recipes**: In Classic TBC, `CRAFT_SHOW` fires for both the Enchanting window and the Beast Training (hunter pet) window. `ScanCraft` was unconditionally assigning all scanned entries to "Enchanting", causing pet abilities (Claw, Dash, Dive, etc.) to appear as Enchanting recipes for hunter characters. Fixed by (1) checking that the player has the Enchanting skill line before scanning and aborting early if not, and (2) skipping any entry whose `craftType == "ability"` as a secondary guard for the Enchanter+Hunter edge case. The same `craftType` guard was applied to `ScanCraftCooldowns`.
+
 ## 1.1.5 — UI Overhaul — 2026-03-01
 
 ### Features
@@ -33,8 +53,6 @@
 - **Quality color cache poisoning**: `GetItemInfo` results are no longer cached when the item cache returns nil (i.e. before the client has loaded the item). A `GET_ITEM_INFO_RECEIVED` listener triggers a one-time panel refresh when outstanding items load in, resolving recipes that appeared white on first open.
 
 - **Expand icons on non-TBC fonts**: Unicode arrow characters (`►`/`▼`) are not present in all TBC client fonts and were rendering as rectangles. Replaced with ASCII `+`/`-`.
-
-- **Hunter pet abilities tracked as Enchanting recipes**: In Classic TBC, `CRAFT_SHOW` fires for both the Enchanting window and the Beast Training (hunter pet) window. `ScanCraft` was unconditionally assigning all scanned entries to "Enchanting", causing pet abilities (Claw, Dash, Dive, etc.) to appear as Enchanting recipes for hunter characters. Fixed by (1) checking that the player has the Enchanting skill line before scanning and aborting early if not, and (2) skipping any entry whose `craftType == "ability"` as a secondary guard for the Enchanter+Hunter edge case. The same `craftType` guard was applied to `ScanCraftCooldowns`.
 
 ## 1.1.0 — 2026-02-27
 

--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -78,6 +78,7 @@ function Comms:OnInitialize()
     self.syncPending       = false
     self.syncRetryCount    = 0
     self.syncTimer         = nil
+    self._postSyncHelloDone = false
 
     -- DR request queue (when we are DR)
     self.syncQueue         = {}
@@ -149,16 +150,25 @@ function Comms:HandleHello(payload, sender)
     self:RecomputeElection()
 
     -- Reply with our own HELLO so the sender discovers us too.
-    -- Only reply to genuinely new users (not replies) to prevent infinite loops.
-    if isNew and not payload.isReply then
+    -- Reply if:
+    --   (a) sender is new to us and didn't send a plain reply (normal discovery), OR
+    --   (b) sender explicitly asked for replies via discover=true (post-sync sweep)
+    -- Always use isReply=true in the response to prevent further cascading.
+    -- Add random jitter (0.5–4.0 s) to avoid a thundering-herd broadcast storm
+    -- when many clients reply to the same HELLO simultaneously.
+    local wantReply = (isNew and not payload.isReply) or (payload.discover and not payload.isReply)
+    if wantReply then
         local playerKey = GuildCrafts.Data:GetPlayerKey()
         if memberKey ~= playerKey then
-            self:SendMessage(MSG_HELLO, {
-                sender  = playerKey,
-                version = GuildCrafts.VERSION,
-                isReply = true,
-            }, "GUILD")
-            GuildCrafts:Debug("Sent HELLO reply to", memberKey)
+            local jitter = 0.5 + math.random() * 3.5  -- 0.5 – 4.0 s
+            self:ScheduleTimer(function()
+                self:SendMessage(MSG_HELLO, {
+                    sender  = playerKey,
+                    version = GuildCrafts.VERSION,
+                    isReply = true,
+                }, "GUILD")
+                GuildCrafts:Debug("Sent HELLO reply to", memberKey)
+            end, jitter)
         end
     end
 
@@ -169,6 +179,34 @@ function Comms:HandleHello(payload, sender)
         self.syncRetryCount = 0
         self:ScheduleTimer("SendSyncRequest", 2)
         GuildCrafts:Debug("Scheduling re-sync after discovering", memberKey)
+    end
+end
+
+----------------------------------------------------------------------
+-- Ensure a node is in addonUsers (called on any inbound message)
+----------------------------------------------------------------------
+
+--- Add or refresh the given key in addonUsers.
+--- Re-elects only when the key is brand new (avoids spurious churn).
+function Comms:TouchAddonUser(key, version)
+    if not key then return end
+    local isNew = not self.addonUsers[key]
+    if isNew then
+        self.addonUsers[key] = {
+            version  = version or 1,
+            lastSeen = time(),
+        }
+        GuildCrafts:Debug("TouchAddonUser: discovered", key)
+        self:RecomputeElection()
+        -- If this demoted us from a false-DR election, RecomputeElection
+        -- already scheduled a sync. If we're still non-DR and haven't synced,
+        -- schedule one now (covers SYNC_REQUEST / SYNC_RESPONSE discovery paths).
+        if self.myRole ~= "DR" and not self.syncPending then
+            self.syncRetryCount = 0
+            self:ScheduleTimer("SendSyncRequest", 2)
+        end
+    else
+        self.addonUsers[key].lastSeen = time()
     end
 end
 
@@ -214,6 +252,15 @@ function Comms:RecomputeElection()
         GuildCrafts:Debug("Role changed:", oldRole, "→", self.myRole,
             "| DR:", self.currentDR or "none",
             "| BDR:", self.currentBDR or "none")
+
+        -- If we were falsely elected DR (only self was known when SendSyncRequest
+        -- fired) and have now been demoted by discovering the real DR, schedule
+        -- a fresh sync so we get the guild data we skipped earlier.
+        if oldRole == "DR" and self.myRole ~= "DR" and not self.syncPending then
+            self.syncRetryCount = 0
+            self:ScheduleTimer("SendSyncRequest", 2)
+            GuildCrafts:Debug("Was false-DR, now demoted — scheduling sync with real DR")
+        end
     end
 
     -- Always ensure DR watchdog is running if we're not DR
@@ -307,42 +354,11 @@ end
 ----------------------------------------------------------------------
 
 function Comms:OnGuildRosterUpdate()
-    if not IsInGuild() then return end
-
-    -- Build set of online guild members
-    local onlineMembers = {}
-    local numMembers = GetNumGuildMembers()
-
-    -- Safety: if roster hasn't fully loaded yet, skip the offline check.
-    -- On login the first GUILD_ROSTER_UPDATE can fire with 0 members.
-    if numMembers < 2 then
-        GuildCrafts:Debug("OnGuildRosterUpdate skipped — roster not ready yet (", numMembers, "members)")
-        return
-    end
-
-    for i = 1, numMembers do
-        local name, _, _, _, _, _, _, _, isOnline = GetGuildRosterInfo(i)
-        if name and isOnline then
-            if not name:find("-") then
-                name = name .. "-" .. GetRealmName()
-            end
-            onlineMembers[name] = true
-        end
-    end
-
-    -- Remove addon users who went offline
-    local changed = false
-    for key, _ in pairs(self.addonUsers) do
-        if not onlineMembers[key] then
-            GuildCrafts:Debug("Addon user offline:", key)
-            self.addonUsers[key] = nil
-            changed = true
-        end
-    end
-
-    if changed then
-        self:RecomputeElection()
-    end
+    -- Online-status cache is already rebuilt by Core.lua before this is called.
+    -- Addon user expiry is handled solely by the DR heartbeat watchdog (180 s),
+    -- which is reliable. Roster-based eviction was removed because
+    -- GetGuildRosterInfo isOnline flags are unreliable at login and cause
+    -- valid addon users to be prematurely evicted.
 end
 
 ----------------------------------------------------------------------
@@ -419,6 +435,9 @@ function Comms:HandleSyncRequest(payload, sender)
 
     -- Don't respond to our own requests
     if requester == playerKey then return end
+
+    -- Any SYNC_REQUEST proves the sender is online with the addon.
+    self:TouchAddonUser(requester)
 
     -- Decide whether we should respond based on role and retry count
     local shouldRespond = false
@@ -540,6 +559,9 @@ end
 function Comms:HandleSyncResponse(payload, sender)
     if not payload.data then return end
 
+    -- The node that responded is definitely online with the addon.
+    self:TouchAddonUser(sender)
+
     local merged = GuildCrafts.Data:MergeIncoming(payload.data)
     GuildCrafts:Debug("Received SYNC_RESPONSE chunk", (payload.chunkIndex or 1),
         "/", (payload.chunkTotal or 1), "from", sender, "— merged:", tostring(merged))
@@ -566,6 +588,26 @@ function Comms:HandleSyncResponse(payload, sender)
     if GuildCrafts.UI and GuildCrafts.UI.Refresh then
         GuildCrafts.UI:Refresh()
     end
+
+    -- Broadcast a second HELLO so nodes whose reply was throttled or
+    -- arrived too late (before we knew the real DR) get a chance to
+    -- add themselves to our addonUsers table and vice-versa.
+    -- Use isReply=true so this doesn't trigger yet another round of replies.
+    if not self._postSyncHelloDone then
+        self._postSyncHelloDone = true
+        self:ScheduleTimer("BroadcastPostSyncHello", 5)
+    end
+end
+
+function Comms:BroadcastPostSyncHello()
+    if not IsInGuild() then return end
+    local playerKey = GuildCrafts.Data:GetPlayerKey()
+    self:SendMessage(MSG_HELLO, {
+        sender   = playerKey,
+        version  = GuildCrafts.VERSION,
+        discover = true,  -- tells all nodes to reply even if they know us already
+    }, "GUILD")
+    GuildCrafts:Debug("Sent post-sync HELLO to gather missed addon users")
 end
 
 ----------------------------------------------------------------------
@@ -657,6 +699,9 @@ function Comms:HandleDeltaUpdate(payload, sender)
     local playerKey = GuildCrafts.Data:GetPlayerKey()
     -- Don't process our own deltas
     if payload.member == playerKey then return end
+
+    -- Seeing a DELTA_UPDATE proves sender is online with the addon.
+    self:TouchAddonUser(sender)
 
     if payload.type == "add" and payload.profession and payload.recipes then
         -- Merge each recipe
@@ -985,15 +1030,30 @@ function Comms:GetAddonUsers()
     return self.addonUsers
 end
 
+--- Get count of addon users who are currently online according to the guild
+--- roster cache. This filters out zombie entries (users who logged off but
+--- haven't yet timed out of addonUsers via the heartbeat watchdog).
+function Comms:GetActiveAddonUserCount()
+    local count = 0
+    local onlineCache = GuildCrafts.Data and GuildCrafts.Data._onlineCache
+    for key, _ in pairs(self.addonUsers) do
+        -- Always count ourselves (we're online by definition)
+        -- and count anyone the roster cache confirms as online.
+        if key == GuildCrafts.Data:GetPlayerKey()
+           or (onlineCache and onlineCache[key]) then
+            count = count + 1
+        end
+    end
+    return count
+end
+
 --- Get sync status for UI indicator.
 --- Returns "synced", "syncing", or "disconnected"
 function Comms:GetSyncStatus()
     if self.syncPending then
         return "syncing"
     end
-    local count = 0
-    for _ in pairs(self.addonUsers) do count = count + 1 end
-    if count <= 1 then
+    if self:GetActiveAddonUserCount() <= 1 then
         return "disconnected"
     end
     return "synced"

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.1.0"
+GuildCrafts.DISPLAY_VERSION = "1.1.5b"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -270,7 +270,89 @@ function Data:GetGuildDB()
     if not self.db.global[guildKey] then
         self.db.global[guildKey] = {}
     end
+
+    -- One-time cleanup: merge/rename keys stored without realm suffix.
+    -- Requires realm name, which is only guaranteed available after login.
+    if not self._realmlessMerged then
+        self:MergeRealmlessKeys(self.db.global[guildKey])
+        self._realmlessMerged = true
+    end
+
     return self.db.global[guildKey]
+end
+
+--- One-time cleanup: find member keys stored without a realm suffix
+--- (e.g. "Betadrul") and merge them into the canonical "Name-Realm" entry.
+--- If the canonical entry is newer, the realmless entry is simply deleted.
+--- If the canonical entry is absent, the realmless entry is renamed.
+function Data:MergeRealmlessKeys(gdb)
+    if not gdb then return end
+    local realm = GetRealmName()
+    if not realm or realm == "" then return end
+
+    local renamed  = 0
+    local merged   = 0
+
+    -- Collect realmless keys first to avoid mutating the table mid-iteration.
+    local realmless = {}
+    for key, entry in pairs(gdb) do
+        if type(entry) == "table" and entry.lastUpdate and not key:find("-") then
+            realmless[#realmless + 1] = key
+        end
+    end
+
+    for _, key in ipairs(realmless) do
+        local entry      = gdb[key]
+        local canonical  = key .. "-" .. realm
+        local existing   = gdb[canonical]
+
+        if not existing then
+            -- No canonical entry — rename in-place
+            gdb[canonical] = entry
+            gdb[key]       = nil
+            renamed = renamed + 1
+            GuildCrafts:Debug("Renamed realmless key", key, "→", canonical)
+        else
+            -- Both exist — keep the one with the more recent lastUpdate,
+            -- merging any professions the winner is missing from the loser.
+            local keepExisting = (existing.lastUpdate or 0) >= (entry.lastUpdate or 0)
+            local winner = keepExisting and existing or entry
+            local loser  = keepExisting and entry    or existing
+
+            -- Back-fill professions/recipes present in loser but absent in winner.
+            -- If the profession exists in winner but is empty (e.g. DetectProfessions
+            -- created it with a newer timestamp but no recipes scanned yet), merge
+            -- individual recipes from the loser so no data is lost.
+            for profName, loserProf in pairs(loser.professions or {}) do
+                if not winner.professions then winner.professions = {} end
+                if not winner.professions[profName] then
+                    -- Profession entirely missing from winner — copy whole block
+                    winner.professions[profName] = loserProf
+                else
+                    -- Profession exists in winner — merge individual recipes
+                    local winnerProf = winner.professions[profName]
+                    if not winnerProf.recipes then winnerProf.recipes = {} end
+                    for recipeKey, recipeData in pairs(loserProf.recipes or {}) do
+                        if not winnerProf.recipes[recipeKey] then
+                            winnerProf.recipes[recipeKey] = recipeData
+                        end
+                    end
+                end
+            end
+
+            gdb[canonical] = winner
+            gdb[key]       = nil
+            merged = merged + 1
+            GuildCrafts:Debug("Merged realmless key", key, "into", canonical)
+        end
+    end
+
+    if renamed > 0 then
+        GuildCrafts:Printf("Cleaned up %d member key(s): added missing realm suffix.", renamed)
+    end
+    if merged > 0 then
+        GuildCrafts:Printf("Cleaned up %d duplicate member key(s): merged realmless into realm entry.", merged)
+    end
 end
 
 --- One-time migration: move flat member entries from db.global into
@@ -1528,17 +1610,50 @@ function Data:GetMembersByProfession()
         end
     end
 
+    -- Deduplicate by character name (the part before the "-" realm suffix).
+    -- Legacy entries may have been stored without a realm suffix (e.g. "Betadrul")
+    -- while current entries are always stored with one ("Betadrul-Firemaw").
+    -- Keep the entry with the most-recent lastUpdate; fall back to recipeCount.
+    for pName, list in pairs(result) do
+        local seen    = {}   -- displayName -> index in deduped
+        local deduped = {}
+        for _, info in ipairs(list) do
+            local displayName = info.key:match("^(.+)-") or info.key
+            local idx = seen[displayName]
+            if not idx then
+                deduped[#deduped + 1] = info
+                seen[displayName] = #deduped
+            else
+                local existing = deduped[idx]
+                local existTs  = existing.entry and existing.entry.lastUpdate or 0
+                local newTs    = info.entry    and info.entry.lastUpdate    or 0
+                if newTs > existTs
+                        or (newTs == existTs and info.recipeCount > existing.recipeCount) then
+                    deduped[idx] = info
+                end
+            end
+        end
+        result[pName] = deduped
+    end
+
     return result
 end
 
 --- Get the count of members who have a given profession.
+--- Deduplicates by character name so legacy no-realm-suffix entries
+--- do not inflate the count.
 function Data:GetProfessionMemberCount(profName)
     local gdb = self:GetGuildDB()
     if not gdb then return 0 end
+    local seen = {}
     local count = 0
-    for _, entry in pairs(gdb) do
+    for memberKey, entry in pairs(gdb) do
         if type(entry) == "table" and entry.professions and entry.professions[profName] then
-            count = count + 1
+            local displayName = memberKey:match("^(.+)-") or memberKey
+            if not seen[displayName] then
+                seen[displayName] = true
+                count = count + 1
+            end
         end
     end
     return count
@@ -1573,6 +1688,21 @@ function Data:GetAllRecipesForProfession(profName)
                 end
             end
         end
+    end
+    -- Deduplicate crafters per recipe by display name so a member who appears
+    -- under two different DB keys (e.g. legacy no-realm-suffix entry + current entry)
+    -- is only listed once per recipe.
+    for _, recipe in pairs(recipeMap) do
+        local seenCrafters   = {}
+        local uniqueCrafters = {}
+        for _, c in ipairs(recipe.crafters) do
+            local displayName = c.key:match("^(.+)-") or c.key
+            if not seenCrafters[displayName] then
+                seenCrafters[displayName] = true
+                uniqueCrafters[#uniqueCrafters + 1] = c
+            end
+        end
+        recipe.crafters = uniqueCrafters
     end
     local results = {}
     for _, recipe in pairs(recipeMap) do
@@ -1620,6 +1750,21 @@ function Data:SearchRecipes(query)
                 end
             end
         end
+    end
+
+    -- Deduplicate crafters by display name (same fix as GetAllRecipesForProfession;
+    -- prevents double-listing when a legacy no-realm key and a current key coexist)
+    for _, v in pairs(resultMap) do
+        local seenCrafters   = {}
+        local uniqueCrafters = {}
+        for _, c in ipairs(v.crafters) do
+            local displayName = c.key:match("^(.+)-") or c.key
+            if not seenCrafters[displayName] then
+                seenCrafters[displayName] = true
+                uniqueCrafters[#uniqueCrafters + 1] = c
+            end
+        end
+        v.crafters = uniqueCrafters
     end
 
     -- Convert map to sorted list

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.1.5
+## Version: 1.1.5b
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild

--- a/GuildCrafts/README.md
+++ b/GuildCrafts/README.md
@@ -58,10 +58,11 @@ Alchemy · Blacksmithing · Enchanting · Engineering · Jewelcrafting · Leathe
 ## How It Works
 
 1. **Open any profession window** — the addon scans all recipes and stores them locally
-2. **On login** — the addon broadcasts a `HELLO` to discover other addon users, then performs a sync
+2. **On login** — the addon broadcasts a `HELLO` to discover other addon users, then performs a sync. A second `discover` HELLO is sent ~15 s after sync completes so nodes whose first reply was throttled are still found
 3. **Designated Router (DR)** — the addon user with the lexicographically lowest character name handles sync requests, preventing channel flooding in large guilds
 4. **Delta updates** — learning a new recipe immediately broadcasts it to all online addon users
 5. **Browse & search** — use the two-panel UI to browse by profession → member → recipes, or search globally
+6. **Sync dot** — the top-right indicator shows green (synced), yellow (syncing), or red (alone). Hover to see the DR name and count of online addon users confirmed by the guild roster
 
 ## Requirements
 

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -152,10 +152,7 @@ function UI:CreateTitleBar(parent)
         GameTooltip:AddLine("Sync Status", 1, 1, 1)
         local status = GuildCrafts.Comms and GuildCrafts.Comms:GetSyncStatus() or "unknown"
         local dr = GuildCrafts.Comms and GuildCrafts.Comms.currentDR or "none"
-        local users = 0
-        if GuildCrafts.Comms and GuildCrafts.Comms.addonUsers then
-            for _ in pairs(GuildCrafts.Comms.addonUsers) do users = users + 1 end
-        end
+        local users = GuildCrafts.Comms and GuildCrafts.Comms:GetActiveAddonUserCount() or 0
         GameTooltip:AddDoubleLine("Status:", status, 0.7, 0.7, 0.7, 1, 1, 1)
         GameTooltip:AddDoubleLine("DR:", dr, 0.7, 0.7, 0.7, 1, 1, 1)
         GameTooltip:AddDoubleLine("Addon users:", tostring(users), 0.7, 0.7, 0.7, 1, 1, 1)

--- a/spec/GuildCrafts-Guide.txt
+++ b/spec/GuildCrafts-Guide.txt
@@ -67,7 +67,9 @@ SYNC DOT (top-right corner)
   Green  = fully synced
   Yellow = sync in progress
   Red    = no connection / alone
-  Hover for details (last sync time, DR identity, user count).
+  Hover for details (DR identity, online addon user count).
+  The count shows only guild members currently online who have
+  the addon — logged-off users are not included.
 
 CRAFT QUEUE BAR (bottom)
   Shows pending craft requests you have accepted.
@@ -144,7 +146,10 @@ You don't need to do anything — this all happens automatically.
 
   1. LOGIN
      Your addon says "hello" to the guild and requests any
-     recipe data you're missing.
+     recipe data you're missing. About 15 seconds after login,
+     a second discovery sweep is broadcast so any addon users
+     whose reply was delayed (e.g. by WoW's message throttle)
+     are found and added to the peer list.
 
   2. COORDINATOR (DR)
      One addon user is automatically elected as the Designated
@@ -170,6 +175,8 @@ You don't need to do anything — this all happens automatically.
      Sync data is split into small batches (10 members per
      message) so it never overwhelms WoW's message system,
      even with hundreds of guild members.
+     Discovery replies also use a small random delay to prevent
+     many clients replying at the exact same moment.
 
 The more guildies who install it, the more complete the
 guild-wide recipe book becomes.


### PR DESCRIPTION
## Summary

Fixes for issues found during testing and peer code review.

### Bug Fixes

**Addon user count inaccurate (sync dot tooltip)**
- *Too low on login*: Race between HELLO broadcast (T+8s) and first `SYNC_REQUEST` (T+10s) caused false DR self-election and skipped sync. `RecomputeElection` now schedules a fresh sync on any DR→non-DR demotion.
- Post-sync `discover` HELLO broadcast 5s after sync completes; all online nodes reply unconditionally, filling `addonUsers` within ~15s.
- `SYNC_REQUEST`, `SYNC_RESPONSE`, and `DELTA_UPDATE` handlers call `TouchAddonUser(sender)` for opportunistic discovery.
- Removed roster-based eviction from `OnGuildRosterUpdate` (unreliable `isOnline` flags at login were prematurely evicting valid users).
- *Too high over time (zombie users)*: Non-DR nodes are never expired by the heartbeat watchdog. `addonUsers` now retains all keys for fast reconnect, but `GetActiveAddonUserCount()` cross-checks against `Data._onlineCache` to show only currently online users. `GetSyncStatus()` uses the same filtered count.

**`MergeRealmlessKeys` back-fill data loss**
Back-fill now merges at the recipe level when the winner already has the profession. Previously, if `DetectProfessions` had created an empty profession shell with a newer timestamp, the loser's recipes for that profession were silently discarded.

**HELLO reply thundering herd**
`discover=true` HELLO replies now use a random 0.5–4.0s jitter to prevent all clients replying at the exact same moment in large guilds.

### Documentation
- CHANGELOG consolidated and corrected
- README "How It Works" updated
- `GuildCrafts-Guide.txt` sync section updated (discovery sweep, jitter note, corrected sync dot description)