### PR TITLE
feat: Multi-locale support — v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.1.6 — Multi-Locale Support — 2026-03-07
+
+### Features
+
+- **Multi-locale guild support** (fixes #8): The addon now works correctly when guild members run different game client languages (English, French, German, etc.).
+  - **Profession scanning**: `GetSkillLineInfo` and `GetTradeSkillLine` return localised profession names ("Alchimie" on a French client). These are now canonicalised to stable English DB keys at scan time using `GetSpellInfo` with each profession's rank-1 spell ID, so a French player's data is stored and shared identically to an English player's.
+  - **Display names localised to the viewer**: Two new helpers — `GetLocalizedRecipeName(recipeKey)` and `GetLocalizedReagentName(reagent)` — resolve item and spell names via `GetItemInfo`/`GetSpellInfo` for the *viewing* client's locale. A recipe scanned in French now displays in English (or any other locale) for every guild member who views it.
+  - **Locale-independent search deduplication**: `SearchRecipes` now keys its result map by `recipeKey|profName` (numeric, locale-independent) rather than the stored recipe name string, so the same recipe scanned in two different languages produces a single combined result entry. Search also matches against both the locally-resolved name and the raw stored name for cross-locale discoverability.
+  - All five reagent display sites in the UI updated to use `GetLocalizedReagentName`.
+
 ## 1.1.5b — 2026-03-03
 
 ### Bug Fixes

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.1.5b"
+GuildCrafts.DISPLAY_VERSION = "1.1.6"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -42,7 +42,7 @@ local tonumber = tonumber
 -- Data staleness threshold (seconds) — 30 days
 local STALE_THRESHOLD = 30 * 24 * 3600
 
--- TBC crafting professions we track
+-- TBC crafting professions we track (canonical English keys)
 local TRACKED_PROFESSIONS = {
     ["Alchemy"] = true,
     ["Blacksmithing"] = true,
@@ -52,6 +52,68 @@ local TRACKED_PROFESSIONS = {
     ["Leatherworking"] = true,
     ["Tailoring"] = true,
 }
+
+----------------------------------------------------------------------
+-- Locale-to-canonical profession name mapping
+-- GetSpellInfo(id) returns the *localised* profession name, which must
+-- match what GetSkillLineInfo / GetTradeSkillLine returns on that client.
+-- Using rank-1 profession spell IDs lets us normalise any locale to the
+-- stable English key used in the DB, TRACKED_PROFESSIONS, etc.
+----------------------------------------------------------------------
+local PROFESSION_SPELL_IDS = {
+    ["Alchemy"]        = 2259,
+    ["Blacksmithing"]  = 2018,
+    ["Enchanting"]     = 7411,
+    ["Engineering"]    = 4036,
+    ["Jewelcrafting"]  = 25229,
+    ["Leatherworking"] = 2108,
+    ["Tailoring"]      = 3908,
+}
+
+-- Populated lazily on first use (GetSpellInfo is not reliable at file-load time)
+local _localeToCanonical = nil
+local function BuildLocaleMap()
+    _localeToCanonical = {}
+    for canonical, spellID in pairs(PROFESSION_SPELL_IDS) do
+        local localizedName = GetSpellInfo(spellID)
+        if localizedName then
+            _localeToCanonical[localizedName] = canonical
+        end
+    end
+end
+
+--- Return the canonical (English) profession name for a possibly-localised input.
+--- Falls back to the input unchanged if the name is already canonical or unknown.
+function Data:GetCanonicalProfName(name)
+    if not _localeToCanonical then BuildLocaleMap() end
+    return _localeToCanonical[name] or name
+end
+
+--- Return the localized recipe name for the viewing client's language.
+--- recipeKey > 0: itemID  → GetItemInfo for the crafted item's name
+--- recipeKey < 0: spellID → GetSpellInfo for the enchant/spell name
+--- Falls back to `fallback` (or "Unknown") when not yet cached.
+function Data:GetLocalizedRecipeName(recipeKey, fallback)
+    if recipeKey and recipeKey > 0 then
+        local name = GetItemInfo(recipeKey)
+        if name then return name end
+    elseif recipeKey and recipeKey < 0 then
+        local name = GetSpellInfo(-recipeKey)
+        if name then return name end
+    end
+    return fallback or "Unknown"
+end
+
+--- Return the localized name for a reagent entry {name, count, itemID}.
+--- Uses GetItemInfo when itemID is available so non-English clients see
+--- their own locale's item names even for recipes scanned in another language.
+function Data:GetLocalizedReagentName(reagent)
+    if reagent.itemID then
+        local name = GetItemInfo(reagent.itemID)
+        if name then return name end
+    end
+    return reagent.name or ""
+end
 
 -- TBC profession specialisations keyed by spellID
 -- Each entry maps to { profession, specName }
@@ -413,13 +475,18 @@ function Data:DetectProfessions()
     if not entry then return end
     local currentProfs = {}
 
-    -- GetSkillLineInfo enumerates all skills including professions
+    -- GetSkillLineInfo enumerates all skills including professions.
+    -- Canonicalize the localized name so non-English clients store the same
+    -- stable English key that TRACKED_PROFESSIONS and the rest of the addon use.
     local skillLevels = {}  -- profName -> { rank, max }
     for i = 1, GetNumSkillLines() do
         local skillName, isHeader, _, skillRank, _, _, skillMaxRank, _, _, _, _, _, _ = GetSkillLineInfo(i)
-        if not isHeader and TRACKED_PROFESSIONS[skillName] then
-            currentProfs[skillName] = true
-            skillLevels[skillName] = { rank = skillRank, max = skillMaxRank }
+        if not isHeader then
+            local canonical = self:GetCanonicalProfName(skillName)
+            if TRACKED_PROFESSIONS[canonical] then
+                currentProfs[canonical] = true
+                skillLevels[canonical] = { rank = skillRank, max = skillMaxRank }
+            end
         end
     end
 
@@ -869,17 +936,18 @@ end
 --- Get the name of the currently open profession window.
 function Data:GetOpenProfessionName()
     -- The first entry in the trade skill list is typically a header with the profession name,
-    -- or we can use GetTradeSkillLine() if available (TBC)
+    -- or we can use GetTradeSkillLine() if available (TBC).
+    -- Always canonicalize so non-English clients return the same stable English key.
     if GetTradeSkillLine then
         local lineName = GetTradeSkillLine()
-        return lineName
+        return lineName and self:GetCanonicalProfName(lineName) or nil
     end
 
     -- Fallback: check first header
     for i = 1, GetNumTradeSkills() do
         local skillName, skillType = GetTradeSkillInfo(i)
         if skillType == "header" then
-            return skillName
+            return self:GetCanonicalProfName(skillName)
         end
     end
 
@@ -903,10 +971,11 @@ function Data:ScanCraft()
 
     -- Guard: CRAFT_SHOW fires for both Enchanting and Beast Training (hunter pet)
     -- windows in Classic TBC. Only scan when the player actually has Enchanting.
+    -- Compare against the canonical name so non-English clients are handled.
     local hasEnchanting = false
     for i = 1, GetNumSkillLines() do
         local skillName, isHeader = GetSkillLineInfo(i)
-        if not isHeader and skillName == "Enchanting" then
+        if not isHeader and self:GetCanonicalProfName(skillName) == "Enchanting" then
             hasEnchanting = true
             break
         end
@@ -927,7 +996,7 @@ function Data:ScanCraft()
     -- Refresh Enchanting skill level while the window is open
     for i = 1, GetNumSkillLines() do
         local skillName, isHeader, _, skillRank, _, _, skillMaxRank = GetSkillLineInfo(i)
-        if not isHeader and skillName == profName then
+        if not isHeader and self:GetCanonicalProfName(skillName) == profName then
             local profDataLocal = entry.professions[profName]
             if profDataLocal.skillLevel ~= skillRank or profDataLocal.maxSkillLevel ~= skillMaxRank then
                 profDataLocal.skillLevel = skillRank
@@ -1675,7 +1744,10 @@ function Data:GetAllRecipesForProfession(profName)
             local profData = entry.professions[profName]
             if profData.recipes then
                 for recipeKey, recipeData in pairs(profData.recipes) do
-                    local name = recipeData.name or "Unknown"
+                    -- Resolve the recipe name in the *viewing* client's locale via
+                    -- GetItemInfo/GetSpellInfo so a recipe scanned in French still
+                    -- shows in English (or German, etc.) for other guild members.
+                    local name = self:GetLocalizedRecipeName(recipeKey, recipeData.name)
                     if not recipeMap[recipeKey] then
                         recipeMap[recipeKey] = {
                             key      = recipeKey,
@@ -1683,6 +1755,11 @@ function Data:GetAllRecipesForProfession(profName)
                             crafters = {},
                             reagents = recipeData.reagents or self:GetRecipeReagents(recipeKey),
                         }
+                    else
+                        -- Update name if we now have a better (locally resolved) one
+                        if name ~= "Unknown" then
+                            recipeMap[recipeKey].name = name
+                        end
                     end
                     recipeMap[recipeKey].crafters[#recipeMap[recipeKey].crafters + 1] = { key = memberKey }
                 end
@@ -1729,17 +1806,35 @@ function Data:SearchRecipes(query)
             for profName, profData in pairs(entry.professions) do
                 if profData.recipes then
                     for recipeKey, recipeData in pairs(profData.recipes) do
-                        if recipeData.name and recipeData.name:lower():find(query, 1, true) then
-                            local mapKey = recipeData.name .. "|" .. profName
+                        -- Always try to resolve the name in the viewing client's locale.
+                        -- Fall back to the stored (possibly foreign-locale) name so that
+                        -- uncached items still appear in results.
+                        local localName = self:GetLocalizedRecipeName(recipeKey, recipeData.name)
+                        local storedName = recipeData.name or ""
+                        -- Match against both the locally-resolved name and the stored name
+                        -- so a French player's "Transmutation: Mercure brut" is still
+                        -- findable by an English player typing "Mercury".
+                        local matchName  = localName ~= "Unknown" and localName or storedName
+                        if matchName:lower():find(query, 1, true)
+                                or (storedName ~= matchName and storedName:lower():find(query, 1, true)) then
+                            -- Use recipeKey+profName as the map key (locale-independent)
+                            -- so the same recipe scanned in two different languages is
+                            -- deduplicated into a single result entry.
+                            local mapKey = tostring(recipeKey) .. "|" .. profName
                             if not resultMap[mapKey] then
                                 resultMap[mapKey] = {
-                                    recipeName = recipeData.name,
+                                    recipeName = localName,
                                     recipeKey = recipeKey,
                                     profName = profName,
                                     source = recipeData.source,
                                     reagents = recipeData.reagents or self:GetRecipeReagents(recipeKey),
                                     crafters = {},
                                 }
+                            else
+                                -- Keep the better (locally resolved) name if available
+                                if localName ~= "Unknown" then
+                                    resultMap[mapKey].recipeName = localName
+                                end
                             end
                             resultMap[mapKey].crafters[#resultMap[mapKey].crafters + 1] = {
                                 key = memberKey,

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.1.5b
+## Version: 1.1.6
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -735,7 +735,7 @@ function UI:ShowMemberRecipes(memberKey, profName)
     for key, data in pairs(recipes) do
         sorted[#sorted + 1] = {
             key = key,
-            name = data.name or "Unknown",
+            name = GuildCrafts.Data:GetLocalizedRecipeName(key, data.name),
             source = data.source or "",
             reagents = data.reagents or GuildCrafts.Data:GetRecipeReagents(key),
             category = data.category or GuildCrafts.Data:GetRecipeCategory(key) or "",
@@ -860,7 +860,7 @@ function UI:ShowMemberRecipes(memberKey, profName)
             for _, r in ipairs(recipe.reagents) do
                 local reagentLine = self.detailContent:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
                 reagentLine:SetPoint("TOPLEFT", self.detailContent, "TOPLEFT", 32, yOffset - 14)
-                reagentLine:SetText(r.count .. "x " .. r.name)
+                reagentLine:SetText(r.count .. "x " .. GuildCrafts.Data:GetLocalizedReagentName(r))
                 reagentLine:SetTextColor(0.6, 0.8, 1.0)
                 self.detailRows[#self.detailRows + 1] = reagentLine
                 yOffset = yOffset - 14
@@ -1021,7 +1021,7 @@ function UI:ShowSearchResults(results)
                 for _, r in ipairs(result.reagents) do
                     local reagentLine = self.detailContent:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
                     reagentLine:SetPoint("TOPLEFT", self.detailContent, "TOPLEFT", 36, yOffset)
-                    reagentLine:SetText(r.count .. "x " .. r.name)
+                    reagentLine:SetText(r.count .. "x " .. GuildCrafts.Data:GetLocalizedReagentName(r))
                     reagentLine:SetTextColor(0.6, 0.8, 1.0)
                     self.detailRows[#self.detailRows + 1] = reagentLine
                     yOffset = yOffset - 14
@@ -1648,7 +1648,7 @@ function UI:ShowFavRecipesDetail(grouped, filterProf)
             if recipe.reagents and #recipe.reagents > 0 then
                 local parts = {}
                 for _, r in ipairs(recipe.reagents) do
-                    parts[#parts + 1] = r.count .. "x " .. r.name
+                    parts[#parts + 1] = r.count .. "x " .. GuildCrafts.Data:GetLocalizedReagentName(r)
                 end
                 local reagentStr = table.concat(parts, ", ")
                 local reagentText = self.detailContent:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
@@ -2295,7 +2295,7 @@ function UI:ShowRecipesView(profName)
             for _, r in ipairs(recipe.reagents) do
                 local reagentLine = self.detailContent:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
                 reagentLine:SetPoint("TOPLEFT", self.detailContent, "TOPLEFT", 28, yOffset)
-                reagentLine:SetText(r.count .. "x " .. r.name)
+                reagentLine:SetText(r.count .. "x " .. GuildCrafts.Data:GetLocalizedReagentName(r))
                 reagentLine:SetTextColor(0.6, 0.8, 1.0)
                 self.detailRows[#self.detailRows + 1] = reagentLine
                 yOffset = yOffset - 14


### PR DESCRIPTION
Fixes #8

## Summary
Addon now works correctly for guilds with mixed client languages (English, French, German, etc.).

### Changes

**`Data.lua`**
- Add `PROFESSION_SPELL_IDS` table with rank-1 spell IDs for all 7 tracked professions
- Add lazy `BuildLocaleMap()` using `GetSpellInfo` to build a localised-name → canonical-English reverse map
- Add `GetCanonicalProfName(name)` — normalises any locale's skill name to the stable English DB key used everywhere
- Add `GetLocalizedRecipeName(recipeKey, fallback)` — resolves crafted item/spell names via `GetItemInfo`/`GetSpellInfo` for the *viewing* client's locale
- Add `GetLocalizedReagentName(reagent)` — same for reagent items, using stored `itemID`
- `DetectProfessions` — canonicalises `GetSkillLineInfo` output before touching `TRACKED_PROFESSIONS` or the DB
- `GetOpenProfessionName` — canonicalises `GetTradeSkillLine` output
- `ScanCraft` — canonicalises `GetSkillLineInfo` output in both the Enchanting guard and skill level refresh
- `GetAllRecipesForProfession` — resolves recipe names in the viewer's locale
- `SearchRecipes` — deduplicates by `recipeKey|profName` (locale-independent); matches against both resolved and stored names

**`UI/MainFrame.lua`**
- All 5 reagent display sites use `GetLocalizedReagentName`
- Member recipe view uses `GetLocalizedRecipeName`

**Version bump**: `1.1.5b` → `1.1.6` in `.toc` and `Core.lua`