### PR TITLE
fix: Locale verification — tooltip and favorites name localisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - **Display names localised to the viewer**: Two new helpers — `GetLocalizedRecipeName(recipeKey)` and `GetLocalizedReagentName(reagent)` — resolve item and spell names via `GetItemInfo`/`GetSpellInfo` for the *viewing* client's locale. A recipe scanned in French now displays in English (or any other locale) for every guild member who views it.
   - **Locale-independent search deduplication**: `SearchRecipes` now keys its result map by `recipeKey|profName` (numeric, locale-independent) rather than the stored recipe name string, so the same recipe scanned in two different languages produces a single combined result entry. Search also matches against both the locally-resolved name and the raw stored name for cross-locale discoverability.
   - All five reagent display sites in the UI updated to use `GetLocalizedReagentName`.
+  - **Tooltip crafter overlay**: The reverse-lookup name index now resolves recipe names in the viewer's locale via `GetLocalizedRecipeName`, so hovering an item correctly shows guild crafters even when the recipe was scanned by a different-language client.
+  - **Favorites tab**: Recipe names on the favorites screen are now localised instead of showing the raw stored (possibly foreign-language) name.
 
 ## 1.1.5b — 2026-03-03
 

--- a/GuildCrafts/Favorites.lua
+++ b/GuildCrafts/Favorites.lua
@@ -99,7 +99,7 @@ function Favorites:GetFavoriteRecipesGrouped()
                             if not recipeMap[recipeKey] then
                                 recipeMap[recipeKey] = {
                                     recipeKey = recipeKey,
-                                    recipeName = recipeData.name or "Unknown",
+                                    recipeName = GuildCrafts.Data:GetLocalizedRecipeName(recipeKey, recipeData.name),
                                     profName = profName,
                                     category = recipeData.category or GuildCrafts.Data:GetRecipeCategory(recipeKey) or "",
                                     reagents = recipeData.reagents or GuildCrafts.Data:GetRecipeReagents(recipeKey),

--- a/GuildCrafts/Tooltip.lua
+++ b/GuildCrafts/Tooltip.lua
@@ -51,8 +51,19 @@ function Tooltip:RebuildIndex()
                             indexByID[recipeKey][#indexByID[recipeKey] + 1] = crafterEntry
                         end
 
-                        -- Index by recipe name (fallback for enchants / name matching)
-                        if recipeData.name then
+                        -- Index by recipe name in the *viewer's* locale so that
+                        -- GetItemInfo(hoveredItem) matches even when the recipe
+                        -- was scanned by a different-language client.
+                        local localName = GuildCrafts.Data:GetLocalizedRecipeName(recipeKey, recipeData.name)
+                        if localName then
+                            if not indexByName[localName] then
+                                indexByName[localName] = {}
+                            end
+                            indexByName[localName][#indexByName[localName] + 1] = crafterEntry
+                        end
+                        -- Also index the stored (possibly foreign-locale) name as
+                        -- a fallback for uncached items.
+                        if recipeData.name and recipeData.name ~= localName then
                             if not indexByName[recipeData.name] then
                                 indexByName[recipeData.name] = {}
                             end


### PR DESCRIPTION
Follow-up to #53 — locale verification pass.

Two gaps found and fixed after auditing the full locale chain from profession name to reagent name:

- **Tooltip crafter overlay** (`Tooltip.lua`): `RebuildIndex` was indexing recipes by `recipeData.name` (the scanner's locale). When a viewer hovered an item, `GetItemInfo` returns their locale's name, which wouldn't match a French-stored name for an English viewer. Fixed by resolving the index key via `GetLocalizedRecipeName` for the viewer's locale, with the stored name kept as a secondary fallback for uncached items.

- **Favorites tab** (`Favorites.lua`): `GetFavoriteRecipesGrouped` was using `recipeData.name or "Unknown"` without localization. Fixed to use `GetLocalizedRecipeName`.