### PR TITLE
feat: LibDBIcon minimap button + specialisation tags in tooltips (1.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.3.4 — 2026-04-05
+
+### Improvements
+
+- **Specialisation tags in item tooltips** — when hovering an item that guild members can craft, any crafter with a profession specialisation now shows it inline: e.g. `PlayerA — Alchemy [Elixir Master]`. Applies to all TBC specs: Alchemy (Potion/Elixir/Transmutation Master), Blacksmithing, Engineering, Leatherworking, and Tailoring. Offline crafters show the spec in grey
+
+### Fixes
+
+- **LibDBIcon-1.0 minimap button** — replaced the custom minimap button implementation with the standard LibDBIcon-1.0 library. Leatrix Plus no longer warns about a non-standard minimap button; the button also works correctly with SexyMap and any other minimap manager automatically. Drag-to-position and `/gc minimap` toggle are unchanged
+
+---
+
 ## 1.3.3 — 2026-03-28
 
 ### Improvements

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.3.3"
+GuildCrafts.DISPLAY_VERSION = "1.3.4"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -207,9 +207,15 @@ local DB_DEFAULTS = {
         --     lastUpdate = timestamp,
         -- }
     },
+    global = {
+        minimap = {
+            hide        = false,
+            minimapPos  = 45,  -- degrees, top-right
+        },
+    },
     profile = {
-        showOnlineOnly     = false,
-        expansionFilter    = { ORIG = true, TBC = true },
+        showOnlineOnly      = false,
+        expansionFilter     = { ORIG = true, TBC = true },
         showTooltipCrafters = true,
     },
 }
@@ -360,7 +366,8 @@ end
 ----------------------------------------------------------------------
 -- Per-guild database partitioning
 -- Each guild's member data lives under db.global["GuildName-Realm"].
--- UI preferences (_minimapAngle, _minimapHide) remain at db.global.
+-- UI preferences (minimap position/visibility) are stored at db.global.minimap
+-- and managed by LibDBIcon-1.0.
 ----------------------------------------------------------------------
 
 --- Return the partition key for the current character's guild, or nil.

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.3.3
+## Version: 1.3.4
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild

--- a/GuildCrafts/Libs/LibDBIcon-1.0/LibDBIcon-1.0.lua
+++ b/GuildCrafts/Libs/LibDBIcon-1.0/LibDBIcon-1.0.lua
@@ -1,0 +1,470 @@
+
+-----------------------------------------------------------------------
+-- LibDBIcon-1.0
+--
+-- Allows addons to easily create a lightweight minimap icon as an alternative to heavier LDB displays.
+--
+
+local DBICON10 = "LibDBIcon-1.0"
+local DBICON10_MINOR = 43 -- Bump on changes
+if not LibStub then error(DBICON10 .. " requires LibStub.") end
+local ldb = LibStub("LibDataBroker-1.1", true)
+if not ldb then error(DBICON10 .. " requires LibDataBroker-1.1.") end
+local lib = LibStub:NewLibrary(DBICON10, DBICON10_MINOR)
+if not lib then return end
+
+lib.objects = lib.objects or {}
+lib.callbackRegistered = lib.callbackRegistered or nil
+lib.callbacks = lib.callbacks or LibStub("CallbackHandler-1.0"):New(lib)
+lib.notCreated = lib.notCreated or {}
+lib.radius = lib.radius or 5
+lib.tooltip = lib.tooltip or CreateFrame("GameTooltip", "LibDBIconTooltip", UIParent, "GameTooltipTemplate")
+local next, Minimap = next, Minimap
+local isDraggingButton = false
+
+function lib:IconCallback(event, name, key, value)
+	if lib.objects[name] then
+		if key == "icon" then
+			lib.objects[name].icon:SetTexture(value)
+		elseif key == "iconCoords" then
+			lib.objects[name].icon:UpdateCoord()
+		elseif key == "iconR" then
+			local _, g, b = lib.objects[name].icon:GetVertexColor()
+			lib.objects[name].icon:SetVertexColor(value, g, b)
+		elseif key == "iconG" then
+			local r, _, b = lib.objects[name].icon:GetVertexColor()
+			lib.objects[name].icon:SetVertexColor(r, value, b)
+		elseif key == "iconB" then
+			local r, g = lib.objects[name].icon:GetVertexColor()
+			lib.objects[name].icon:SetVertexColor(r, g, value)
+		end
+	end
+end
+if not lib.callbackRegistered then
+	ldb.RegisterCallback(lib, "LibDataBroker_AttributeChanged__icon", "IconCallback")
+	ldb.RegisterCallback(lib, "LibDataBroker_AttributeChanged__iconCoords", "IconCallback")
+	ldb.RegisterCallback(lib, "LibDataBroker_AttributeChanged__iconR", "IconCallback")
+	ldb.RegisterCallback(lib, "LibDataBroker_AttributeChanged__iconG", "IconCallback")
+	ldb.RegisterCallback(lib, "LibDataBroker_AttributeChanged__iconB", "IconCallback")
+	lib.callbackRegistered = true
+end
+
+local function getAnchors(frame)
+	local x, y = frame:GetCenter()
+	if not x or not y then return "CENTER" end
+	local hhalf = (x > UIParent:GetWidth()*2/3) and "RIGHT" or (x < UIParent:GetWidth()/3) and "LEFT" or ""
+	local vhalf = (y > UIParent:GetHeight()/2) and "TOP" or "BOTTOM"
+	return vhalf..hhalf, frame, (vhalf == "TOP" and "BOTTOM" or "TOP")..hhalf
+end
+
+local function onEnter(self)
+	if isDraggingButton then return end
+
+	for _, button in next, lib.objects do
+		if button.showOnMouseover then
+			button.fadeOut:Stop()
+			button:SetAlpha(1)
+		end
+	end
+
+	local obj = self.dataObject
+	if obj.OnTooltipShow then
+		lib.tooltip:SetOwner(self, "ANCHOR_NONE")
+		lib.tooltip:SetPoint(getAnchors(self))
+		obj.OnTooltipShow(lib.tooltip)
+		lib.tooltip:Show()
+	elseif obj.OnEnter then
+		obj.OnEnter(self)
+	end
+end
+
+local function onLeave(self)
+	lib.tooltip:Hide()
+
+	if not isDraggingButton then
+		for _, button in next, lib.objects do
+			if button.showOnMouseover then
+				button.fadeOut:Play()
+			end
+		end
+	end
+
+	local obj = self.dataObject
+	if obj.OnLeave then
+		obj.OnLeave(self)
+	end
+end
+
+--------------------------------------------------------------------------------
+
+local onDragStart, updatePosition
+
+do
+	local minimapShapes = {
+		["ROUND"] = {true, true, true, true},
+		["SQUARE"] = {false, false, false, false},
+		["CORNER-TOPLEFT"] = {false, false, false, true},
+		["CORNER-TOPRIGHT"] = {false, false, true, false},
+		["CORNER-BOTTOMLEFT"] = {false, true, false, false},
+		["CORNER-BOTTOMRIGHT"] = {true, false, false, false},
+		["SIDE-LEFT"] = {false, true, false, true},
+		["SIDE-RIGHT"] = {true, false, true, false},
+		["SIDE-TOP"] = {false, false, true, true},
+		["SIDE-BOTTOM"] = {true, true, false, false},
+		["TRICORNER-TOPLEFT"] = {false, true, true, true},
+		["TRICORNER-TOPRIGHT"] = {true, false, true, true},
+		["TRICORNER-BOTTOMLEFT"] = {true, true, false, true},
+		["TRICORNER-BOTTOMRIGHT"] = {true, true, true, false},
+	}
+
+	local rad, cos, sin, sqrt, max, min = math.rad, math.cos, math.sin, math.sqrt, math.max, math.min
+	function updatePosition(button, position)
+		local angle = rad(position or 225)
+		local x, y, q = cos(angle), sin(angle), 1
+		if x < 0 then q = q + 1 end
+		if y > 0 then q = q + 2 end
+		local minimapShape = GetMinimapShape and GetMinimapShape() or "ROUND"
+		local quadTable = minimapShapes[minimapShape]
+		local w = (Minimap:GetWidth() / 2) + lib.radius
+		local h = (Minimap:GetHeight() / 2) + lib.radius
+		if quadTable[q] then
+			x, y = x*w, y*h
+		else
+			local diagRadiusW = sqrt(2*(w)^2)-10
+			local diagRadiusH = sqrt(2*(h)^2)-10
+			x = max(-w, min(x*diagRadiusW, w))
+			y = max(-h, min(y*diagRadiusH, h))
+		end
+		button:SetPoint("CENTER", Minimap, "CENTER", x, y)
+	end
+end
+
+local function onClick(self, b)
+	if self.dataObject.OnClick then
+		self.dataObject.OnClick(self, b)
+	end
+end
+
+local function onMouseDown(self)
+	self.isMouseDown = true
+	self.icon:UpdateCoord()
+end
+
+local function onMouseUp(self)
+	self.isMouseDown = false
+	self.icon:UpdateCoord()
+end
+
+do
+	local deg, atan2 = math.deg, math.atan2
+	local function onUpdate(self)
+		local mx, my = Minimap:GetCenter()
+		local px, py = GetCursorPosition()
+		local scale = Minimap:GetEffectiveScale()
+		px, py = px / scale, py / scale
+		local pos = 225
+		if self.db then
+			pos = deg(atan2(py - my, px - mx)) % 360
+			self.db.minimapPos = pos
+		else
+			pos = deg(atan2(py - my, px - mx)) % 360
+			self.minimapPos = pos
+		end
+		updatePosition(self, pos)
+	end
+
+	function onDragStart(self)
+		self:LockHighlight()
+		self.isMouseDown = true
+		self.icon:UpdateCoord()
+		self:SetScript("OnUpdate", onUpdate)
+		isDraggingButton = true
+		lib.tooltip:Hide()
+		for _, button in next, lib.objects do
+			if button.showOnMouseover then
+				button.fadeOut:Stop()
+				button:SetAlpha(1)
+			end
+		end
+	end
+end
+
+local function onDragStop(self)
+	self:SetScript("OnUpdate", nil)
+	self.isMouseDown = false
+	self.icon:UpdateCoord()
+	self:UnlockHighlight()
+	isDraggingButton = false
+	for _, button in next, lib.objects do
+		if button.showOnMouseover then
+			button.fadeOut:Play()
+		end
+	end
+end
+
+local defaultCoords = {0, 1, 0, 1}
+local function updateCoord(self)
+	local coords = self:GetParent().dataObject.iconCoords or defaultCoords
+	local deltaX, deltaY = 0, 0
+	if not self:GetParent().isMouseDown then
+		deltaX = (coords[2] - coords[1]) * 0.05
+		deltaY = (coords[4] - coords[3]) * 0.05
+	end
+	self:SetTexCoord(coords[1] + deltaX, coords[2] - deltaX, coords[3] + deltaY, coords[4] - deltaY)
+end
+
+local function createButton(name, object, db)
+	local button = CreateFrame("Button", "LibDBIcon10_"..name, Minimap)
+	button.dataObject = object
+	button.db = db
+	button:SetFrameStrata("MEDIUM")
+	button:SetSize(31, 31)
+	button:SetFrameLevel(8)
+	button:RegisterForClicks("anyUp")
+	button:RegisterForDrag("LeftButton")
+	button:SetHighlightTexture(136477) --"Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight"
+	local overlay = button:CreateTexture(nil, "OVERLAY")
+	overlay:SetSize(53, 53)
+	overlay:SetTexture(136430) --"Interface\\Minimap\\MiniMap-TrackingBorder"
+	overlay:SetPoint("TOPLEFT")
+	local background = button:CreateTexture(nil, "BACKGROUND")
+	background:SetSize(20, 20)
+	background:SetTexture(136467) --"Interface\\Minimap\\UI-Minimap-Background"
+	background:SetPoint("TOPLEFT", 7, -5)
+	local icon = button:CreateTexture(nil, "ARTWORK")
+	icon:SetSize(17, 17)
+	icon:SetTexture(object.icon)
+	icon:SetPoint("TOPLEFT", 7, -6)
+	button.icon = icon
+	button.isMouseDown = false
+
+	local r, g, b = icon:GetVertexColor()
+	icon:SetVertexColor(object.iconR or r, object.iconG or g, object.iconB or b)
+
+	icon.UpdateCoord = updateCoord
+	icon:UpdateCoord()
+
+	button:SetScript("OnEnter", onEnter)
+	button:SetScript("OnLeave", onLeave)
+	button:SetScript("OnClick", onClick)
+	if not db or not db.lock then
+		button:SetScript("OnDragStart", onDragStart)
+		button:SetScript("OnDragStop", onDragStop)
+	end
+	button:SetScript("OnMouseDown", onMouseDown)
+	button:SetScript("OnMouseUp", onMouseUp)
+
+	button.fadeOut = button:CreateAnimationGroup()
+	local animOut = button.fadeOut:CreateAnimation("Alpha")
+	animOut:SetOrder(1)
+	animOut:SetDuration(0.2)
+	animOut:SetFromAlpha(1)
+	animOut:SetToAlpha(0)
+	animOut:SetStartDelay(1)
+	button.fadeOut:SetToFinalAlpha(true)
+
+	lib.objects[name] = button
+
+	if lib.loggedIn then
+		updatePosition(button, db and db.minimapPos)
+		if not db or not db.hide then
+			button:Show()
+		else
+			button:Hide()
+		end
+	end
+	lib.callbacks:Fire("LibDBIcon_IconCreated", button, name) -- Fire 'Icon Created' callback
+end
+
+-- We could use a metatable.__index on lib.objects, but then we'd create
+-- the icons when checking things like :IsRegistered, which is not necessary.
+local function check(name)
+	if lib.notCreated[name] then
+		createButton(name, lib.notCreated[name][1], lib.notCreated[name][2])
+		lib.notCreated[name] = nil
+	end
+end
+
+-- Wait a bit with the initial positioning to let any GetMinimapShape addons
+-- load up.
+if not lib.loggedIn then
+	local f = CreateFrame("Frame")
+	f:SetScript("OnEvent", function(f)
+		for _, button in next, lib.objects do
+			updatePosition(button, button.db and button.db.minimapPos)
+			if not button.db or not button.db.hide then
+				button:Show()
+			else
+				button:Hide()
+			end
+		end
+		lib.loggedIn = true
+		f:SetScript("OnEvent", nil)
+	end)
+	f:RegisterEvent("PLAYER_LOGIN")
+end
+
+local function getDatabase(name)
+	return lib.notCreated[name] and lib.notCreated[name][2] or lib.objects[name].db
+end
+
+function lib:Register(name, object, db)
+	if not object.icon then error("Can't register LDB objects without icons set!") end
+	if lib.objects[name] or lib.notCreated[name] then error(DBICON10.. ": Object '".. name .."' is already registered.") end
+	if not db or not db.hide then
+		createButton(name, object, db)
+	else
+		lib.notCreated[name] = {object, db}
+	end
+end
+
+function lib:Lock(name)
+	if not lib:IsRegistered(name) then return end
+	if lib.objects[name] then
+		lib.objects[name]:SetScript("OnDragStart", nil)
+		lib.objects[name]:SetScript("OnDragStop", nil)
+	end
+	local db = getDatabase(name)
+	if db then
+		db.lock = true
+	end
+end
+
+function lib:Unlock(name)
+	if not lib:IsRegistered(name) then return end
+	if lib.objects[name] then
+		lib.objects[name]:SetScript("OnDragStart", onDragStart)
+		lib.objects[name]:SetScript("OnDragStop", onDragStop)
+	end
+	local db = getDatabase(name)
+	if db then
+		db.lock = nil
+	end
+end
+
+function lib:Hide(name)
+	if not lib.objects[name] then return end
+	lib.objects[name]:Hide()
+end
+
+function lib:Show(name)
+	check(name)
+	local button = lib.objects[name]
+	if button then
+		button:Show()
+		updatePosition(button, button.db and button.db.minimapPos or button.minimapPos)
+	end
+end
+
+function lib:IsRegistered(name)
+	return (lib.objects[name] or lib.notCreated[name]) and true or false
+end
+
+function lib:Refresh(name, db)
+	check(name)
+	local button = lib.objects[name]
+	if db then
+		button.db = db
+	end
+	updatePosition(button, button.db and button.db.minimapPos or button.minimapPos)
+	if not button.db or not button.db.hide then
+		button:Show()
+	else
+		button:Hide()
+	end
+	if not button.db or not button.db.lock then
+		button:SetScript("OnDragStart", onDragStart)
+		button:SetScript("OnDragStop", onDragStop)
+	else
+		button:SetScript("OnDragStart", nil)
+		button:SetScript("OnDragStop", nil)
+	end
+end
+
+function lib:GetMinimapButton(name)
+	return lib.objects[name]
+end
+
+do
+	local function OnMinimapEnter()
+		if isDraggingButton then return end
+		for _, button in next, lib.objects do
+			if button.showOnMouseover then
+				button.fadeOut:Stop()
+				button:SetAlpha(1)
+			end
+		end
+	end
+	local function OnMinimapLeave()
+		if isDraggingButton then return end
+		for _, button in next, lib.objects do
+			if button.showOnMouseover then
+				button.fadeOut:Play()
+			end
+		end
+	end
+	Minimap:HookScript("OnEnter", OnMinimapEnter)
+	Minimap:HookScript("OnLeave", OnMinimapLeave)
+
+	function lib:ShowOnEnter(name, value)
+		local button = lib.objects[name]
+		if button then
+			if value then
+				button.showOnMouseover = true
+				button.fadeOut:Stop()
+				button:SetAlpha(0)
+			else
+				button.showOnMouseover = false
+				button.fadeOut:Stop()
+				button:SetAlpha(1)
+			end
+		end
+	end
+end
+
+function lib:GetButtonList()
+	local t = {}
+	for name in next, lib.objects do
+		t[#t+1] = name
+	end
+	return t
+end
+
+function lib:SetButtonRadius(radius)
+	if type(radius) == "number" then
+		lib.radius = radius
+		for _, button in next, lib.objects do
+			updatePosition(button, button.db and button.db.minimapPos or button.minimapPos)
+		end
+	end
+end
+
+function lib:SetButtonToPosition(button, position)
+	updatePosition(lib.objects[button] or button, position)
+end
+
+-- Upgrade!
+for name, button in next, lib.objects do
+	local db = getDatabase(name)
+	if not db or not db.lock then
+		button:SetScript("OnDragStart", onDragStart)
+		button:SetScript("OnDragStop", onDragStop)
+	end
+	button:SetScript("OnEnter", onEnter)
+	button:SetScript("OnLeave", onLeave)
+	button:SetScript("OnClick", onClick)
+	button:SetScript("OnMouseDown", onMouseDown)
+	button:SetScript("OnMouseUp", onMouseUp)
+
+	if not button.fadeOut then -- Upgrade to 39
+		button.fadeOut = button:CreateAnimationGroup()
+		local animOut = button.fadeOut:CreateAnimation("Alpha")
+		animOut:SetOrder(1)
+		animOut:SetDuration(0.2)
+		animOut:SetFromAlpha(1)
+		animOut:SetToAlpha(0)
+		animOut:SetStartDelay(1)
+		button.fadeOut:SetToFinalAlpha(true)
+	end
+end
+lib:SetButtonRadius(lib.radius) -- Upgrade to 40

--- a/GuildCrafts/Libs/LibDataBroker-1.1/LibDataBroker-1.1.lua
+++ b/GuildCrafts/Libs/LibDataBroker-1.1/LibDataBroker-1.1.lua
@@ -1,0 +1,90 @@
+
+assert(LibStub, "LibDataBroker-1.1 requires LibStub")
+assert(LibStub:GetLibrary("CallbackHandler-1.0", true), "LibDataBroker-1.1 requires CallbackHandler-1.0")
+
+local lib, oldminor = LibStub:NewLibrary("LibDataBroker-1.1", 4)
+if not lib then return end
+oldminor = oldminor or 0
+
+
+lib.callbacks = lib.callbacks or LibStub:GetLibrary("CallbackHandler-1.0"):New(lib)
+lib.attributestorage, lib.namestorage, lib.proxystorage = lib.attributestorage or {}, lib.namestorage or {}, lib.proxystorage or {}
+local attributestorage, namestorage, callbacks = lib.attributestorage, lib.namestorage, lib.callbacks
+
+if oldminor < 2 then
+	lib.domt = {
+		__metatable = "access denied",
+		__index = function(self, key) return attributestorage[self] and attributestorage[self][key] end,
+	}
+end
+
+if oldminor < 3 then
+	lib.domt.__newindex = function(self, key, value)
+		if not attributestorage[self] then attributestorage[self] = {} end
+		if attributestorage[self][key] == value then return end
+		attributestorage[self][key] = value
+		local name = namestorage[self]
+		if not name then return end
+		callbacks:Fire("LibDataBroker_AttributeChanged", name, key, value, self)
+		callbacks:Fire("LibDataBroker_AttributeChanged_"..name, name, key, value, self)
+		callbacks:Fire("LibDataBroker_AttributeChanged_"..name.."_"..key, name, key, value, self)
+		callbacks:Fire("LibDataBroker_AttributeChanged__"..key, name, key, value, self)
+	end
+end
+
+if oldminor < 2 then
+	function lib:NewDataObject(name, dataobj)
+		if self.proxystorage[name] then return end
+
+		if dataobj then
+			assert(type(dataobj) == "table", "Invalid dataobj, must be nil or a table")
+			self.attributestorage[dataobj] = {}
+			for i,v in pairs(dataobj) do
+				self.attributestorage[dataobj][i] = v
+				dataobj[i] = nil
+			end
+		end
+		dataobj = setmetatable(dataobj or {}, self.domt)
+		self.proxystorage[name], self.namestorage[dataobj] = dataobj, name
+		self.callbacks:Fire("LibDataBroker_DataObjectCreated", name, dataobj)
+		return dataobj
+	end
+end
+
+if oldminor < 1 then
+	function lib:DataObjectIterator()
+		return pairs(self.proxystorage)
+	end
+
+	function lib:GetDataObjectByName(dataobjectname)
+		return self.proxystorage[dataobjectname]
+	end
+
+	function lib:GetNameByDataObject(dataobject)
+		return self.namestorage[dataobject]
+	end
+end
+
+if oldminor < 4 then
+	local next = pairs(attributestorage)
+	function lib:pairs(dataobject_or_name)
+		local t = type(dataobject_or_name)
+		assert(t == "string" or t == "table", "Usage: ldb:pairs('dataobjectname') or ldb:pairs(dataobject)")
+
+		local dataobj = self.proxystorage[dataobject_or_name] or dataobject_or_name
+		assert(attributestorage[dataobj], "Data object not found")
+
+		return next, attributestorage[dataobj], nil
+	end
+
+	local ipairs_iter = ipairs(attributestorage)
+	function lib:ipairs(dataobject_or_name)
+		local t = type(dataobject_or_name)
+		assert(t == "string" or t == "table", "Usage: ldb:ipairs('dataobjectname') or ldb:ipairs(dataobject)")
+
+		local dataobj = self.proxystorage[dataobject_or_name] or dataobject_or_name
+		assert(attributestorage[dataobj], "Data object not found")
+
+		return ipairs_iter, attributestorage[dataobj], 0
+	end
+end

--- a/GuildCrafts/Libs/embeds.xml
+++ b/GuildCrafts/Libs/embeds.xml
@@ -24,4 +24,8 @@
     <!-- LibDeflate -->
     <Include file="LibDeflate\lib.xml"/>
 
+    <!-- LibDataBroker + LibDBIcon (minimap button) -->
+    <Script file="LibDataBroker-1.1\LibDataBroker-1.1.lua"/>
+    <Script file="LibDBIcon-1.0\LibDBIcon-1.0.lua"/>
+
 </Ui>

--- a/GuildCrafts/MinimapButton.lua
+++ b/GuildCrafts/MinimapButton.lua
@@ -1,162 +1,57 @@
 ----------------------------------------------------------------------
 -- GuildCrafts Minimap Button
--- Lightweight minimap icon — toggle the main window with one click.
+-- Uses LibDBIcon-1.0 for standard minimap icon behaviour,
+-- compatible with Leatrix Plus, SexyMap, and other minimap managers.
 ----------------------------------------------------------------------
 
-local GuildCrafts = LibStub("AceAddon-3.0"):GetAddon("GuildCrafts")
+local GuildCrafts = _G.GuildCrafts
 local MinimapButton = GuildCrafts:NewModule("MinimapButton", "AceEvent-3.0")
 GuildCrafts.MinimapButton = MinimapButton
 
-----------------------------------------------------------------------
--- Constants
-----------------------------------------------------------------------
+local icon = LibStub("LibDBIcon-1.0")
 
-local ICON_TEXTURE = "Interface\\Icons\\INV_Misc_Book_11"
-local BUTTON_SIZE  = 31
-local DRAG_RADIUS  = 80  -- distance from minimap centre
-
-----------------------------------------------------------------------
--- Button Creation
-----------------------------------------------------------------------
-
-local function CreateButton()
-    local btn = CreateFrame("Button", "GuildCraftsMinimapButton", Minimap)
-    btn:SetFrameStrata("MEDIUM")
-    btn:SetFrameLevel(8)
-    btn:SetSize(BUTTON_SIZE, BUTTON_SIZE)
-    btn:SetMovable(true)
-    btn:EnableMouse(true)
-    btn:RegisterForClicks("LeftButtonUp")
-    btn:RegisterForDrag("LeftButton")
-    btn:SetHighlightTexture("Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight")
-
-    -- Border overlay (standard minimap button look)
-    local overlay = btn:CreateTexture(nil, "OVERLAY")
-    overlay:SetSize(53, 53)
-    overlay:SetTexture("Interface\\Minimap\\MiniMap-TrackingBorder")
-    overlay:SetPoint("TOPLEFT")
-
-    -- Icon
-    local icon = btn:CreateTexture(nil, "BACKGROUND")
-    icon:SetSize(20, 20)
-    icon:SetTexture(ICON_TEXTURE)
-    icon:SetPoint("CENTER", btn, "CENTER", 0, 1)
-    btn.icon = icon
-
-    return btn
-end
-
-----------------------------------------------------------------------
--- Position Helpers
-----------------------------------------------------------------------
-
---- Detect whether the minimap is rendered as a square (e.g. SexyMap,
---- BasicMinimap, or any addon that swaps the mask texture).
-local function IsMinimapRound()
-    if Minimap.GetMaskTexture then
-        local mask = Minimap:GetMaskTexture()
-        if mask and not mask:lower():find("minimapmask") then
-            return false
+local ldb = LibStub("LibDataBroker-1.1"):NewDataObject("GuildCrafts", {
+    type = "launcher",
+    icon = "Interface\\Icons\\INV_Misc_Book_11",
+    OnClick = function(_, button)
+        if button == "LeftButton" then
+            GuildCrafts.UI:Toggle()
         end
-    end
-    return true  -- default WoW minimap is round
-end
-
-local function UpdatePosition(btn, angle)
-    local x = math.cos(angle)
-    local y = math.sin(angle)
-
-    if not IsMinimapRound() then
-        -- Project the circular unit vector onto the square perimeter.
-        -- Dividing by max(|x|,|y|) scales the larger component to ±1,
-        -- keeping the angle identical but hugging the square edge.
-        local q = math.max(math.abs(x), math.abs(y))
-        if q > 0 then
-            x = x / q
-            y = y / q
-        end
-    end
-
-    btn:ClearAllPoints()
-    btn:SetPoint("CENTER", Minimap, "CENTER", x * DRAG_RADIUS, y * DRAG_RADIUS)
-end
-
-local function AngleFromCursor()
-    local mx, my = Minimap:GetCenter()
-    local cx, cy = GetCursorPosition()
-    local scale   = Minimap:GetEffectiveScale()
-    cx, cy = cx / scale, cy / scale
-    return math.atan2(cy - my, cx - mx)
-end
+    end,
+    OnTooltipShow = function(tooltip)
+        tooltip:AddLine("GuildCrafts")
+        tooltip:AddLine("|cffffffffLeft-click|r to toggle window", 0.8, 0.8, 0.8)
+    end,
+})
 
 ----------------------------------------------------------------------
 -- Module Lifecycle
 ----------------------------------------------------------------------
 
 function MinimapButton:OnEnable()
-    self.btn = CreateButton()
-
-    -- Restore saved angle or default to top-right
-    local db = GuildCrafts.db
-    if not db.global._minimapAngle then
-        db.global._minimapAngle = 0.785  -- ~45° (top-right)
-    end
-    UpdatePosition(self.btn, db.global._minimapAngle)
-
-    -- Visibility
-    if db.global._minimapHide then
-        self.btn:Hide()
-    end
-
-    -- Click handler
-    self.btn:SetScript("OnClick", function(_, button)
-        if button == "LeftButton" then
-            GuildCrafts.UI:Toggle()
-        end
-    end)
-
-    -- Tooltip
-    self.btn:SetScript("OnEnter", function(frame)
-        GameTooltip:SetOwner(frame, "ANCHOR_LEFT")
-        GameTooltip:AddLine("GuildCrafts")
-        GameTooltip:AddLine("|cffffffffLeft-click|r to toggle window", 0.8, 0.8, 0.8)
-        GameTooltip:Show()
-    end)
-    self.btn:SetScript("OnLeave", function()
-        GameTooltip:Hide()
-    end)
-
-    -- Drag
-    self.btn:SetScript("OnDragStart", function(frame)
-        frame.isDragging = true
-        frame:SetScript("OnUpdate", function()
-            local angle = AngleFromCursor()
-            UpdatePosition(frame, angle)
-            db.global._minimapAngle = angle
-        end)
-    end)
-    self.btn:SetScript("OnDragStop", function(frame)
-        frame.isDragging = false
-        frame:SetScript("OnUpdate", nil)
-    end)
+    -- GuildCrafts.db is set up by Data:OnInitialize before modules are enabled.
+    icon:Register("GuildCrafts", ldb, GuildCrafts.db.global.minimap)
 end
+
+----------------------------------------------------------------------
+-- Public API
+----------------------------------------------------------------------
 
 --- Toggle minimap button visibility.
 --- Pass silent=true to suppress the chat print (e.g. when called from the UI).
 function MinimapButton:Toggle(silent)
-    if not self.btn then return end
-    local db = GuildCrafts.db
-    if self.btn:IsShown() then
-        self.btn:Hide()
-        db.global._minimapHide = true
-        if not silent then
-            GuildCrafts:Print("Minimap button hidden. Type /gc minimap to show it again.")
-        end
-    else
-        self.btn:Show()
-        db.global._minimapHide = false
+    local db = GuildCrafts.db.global.minimap
+    if db.hide then
+        icon:Show("GuildCrafts")
+        db.hide = false
         if not silent then
             GuildCrafts:Print("Minimap button shown.")
+        end
+    else
+        icon:Hide("GuildCrafts")
+        db.hide = true
+        if not silent then
+            GuildCrafts:Print("Minimap button hidden. Type /gc minimap to show it again.")
         end
     end
 end

--- a/GuildCrafts/Tooltip.lua
+++ b/GuildCrafts/Tooltip.lua
@@ -48,7 +48,7 @@ function Tooltip:RebuildIndex()
             for profName, profData in pairs(entry.professions) do
                 if profData.recipes then
                     for recipeKey, recipeData in pairs(profData.recipes) do
-                        local crafterEntry = { key = memberKey, profName = profName }
+                        local crafterEntry = { key = memberKey, profName = profName, spec = profData.specialisation }
 
                         -- Index by recipeKey (itemID for items, negative spellID for enchants)
                         if type(recipeKey) == "number" and recipeKey > 0 then
@@ -143,16 +143,17 @@ function Tooltip:OnTooltipSetItem(tooltip)
 
         local name = crafter.key:match("^(.+)-") or crafter.key
         local isOnline = GuildCrafts.Data:IsMemberOnline(crafter.key)
+        local specSuffix = crafter.spec and (" [" .. crafter.spec .. "]") or ""
 
         if isOnline then
             tooltip:AddDoubleLine(
                 "  |cff00ff00" .. name .. "|r",
-                "|cff888888" .. crafter.profName .. "|r"
+                "|cff888888" .. crafter.profName .. "|r" .. (crafter.spec and (" |cffffcc00[" .. crafter.spec .. "]|r") or "")
             )
         else
             tooltip:AddDoubleLine(
                 "  |cff666666" .. name .. "|r",
-                "|cff666666" .. crafter.profName .. "|r"
+                "|cff666666" .. crafter.profName .. specSuffix .. "|r"
             )
         end
         shown = shown + 1

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -2511,7 +2511,7 @@ end
 --- Update the [Minimap] button visual to match the current setting.
 function UI:_UpdateMinimapBtnVisuals()
     if not self._minimapBtn then return end
-    local hidden = GuildCrafts.db and GuildCrafts.db.global._minimapHide
+    local hidden = GuildCrafts.db and GuildCrafts.db.global.minimap and GuildCrafts.db.global.minimap.hide
     if not hidden then
         self._minimapBtn:SetBackdropColor(0.12, 0.12, 0.12, 1)
         self._minimapBtn:SetBackdropBorderColor(1, 0.82, 0, 1)


### PR DESCRIPTION
## Changes

- **LibDBIcon-1.0 minimap button** — replaces the custom minimap frame implementation. Fixes the Leatrix Plus warning about non-standard minimap buttons; works correctly with SexyMap and any other minimap manager
- **Specialisation tags in item tooltips** — crafters with a TBC spec now show it inline when hovering a craftable item (e.g. `Alchemy [Elixir Master]` in gold for online, grey for offline)

Tested in-game.