### PR TITLE
fix: lower main frame strata from HIGH to MEDIUM (1.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.5 — 2026-04-11
+
+### Fixes
+
+- **GuildCrafts window no longer covers other windows** — the main frame was set to `HIGH` strata, which placed it on top of Blizzard UI panels including the tradeskill window, bags, and character sheet. Changed to `MEDIUM` so it behaves like a normal addon window and yields to game UI frames
+
+---
+
 ## 1.3.4 — 2026-04-05
 
 ### Improvements

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.3.4"
+GuildCrafts.DISPLAY_VERSION = "1.3.5"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.3.4
+## Version: 1.3.5
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -104,7 +104,7 @@ function UI:CreateMainFrame()
     f:SetMovable(true)
     f:SetResizable(true)
     f:SetClampedToScreen(true)
-    f:SetFrameStrata("HIGH")
+    f:SetFrameStrata("MEDIUM")
     f:SetToplevel(true)
     f:EnableMouse(true)
 


### PR DESCRIPTION
The main frame was using `HIGH` strata, causing it to render on top of all Blizzard UI panels (tradeskill window, bags, character sheet). Changed to `MEDIUM` so the GuildCrafts window behaves like a normal addon window.