### PR TITLE
fix: always refresh lastUpdate on profession scan, broadcast touch when stale (v1.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
     # Changelog
 
+## 1.3.7 — 2026-04-21
+
+### Fixes
+
+- **Stale-data warning never resolved when all recipes were already learned** — opening a profession window only updated your sync timestamp when new recipes or a skill level change were detected. Players who had learned everything would keep aging toward the prune threshold even while actively playing. The addon now always refreshes the timestamp when a profession window is opened, regardless of whether anything changed.
+
+- **Peers and the Designated Requester could prune an active player** — because the timestamp update was local-only, other guild members' clients (and the DR) still saw the old timestamp and would eventually prune the entry at 45 days. The addon now broadcasts a lightweight `DELTA_UPDATE (touch)` message to the guild when data is 25–45 days old, so all peers stay in sync. To avoid unnecessary traffic the broadcast is rate-limited to once per hour per profession.
+
+---
+
 ## 1.3.6a — 2026-04-15
 
 ### Fixes

--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -780,6 +780,31 @@ function Comms:BroadcastProfessionRemoval(memberKey, profName)
     GuildCrafts:Debug("Broadcast DELTA_UPDATE (remove) for", memberKey, profName)
 end
 
+--- Broadcast a lightweight timestamp-only update. Called when a profession window
+--- is opened but no new recipes are found and the data is 25+ days old. This
+--- prevents peers (including the DR) from pruning a player who is simply up to
+--- date and has nothing new to learn.
+function Comms:BroadcastTimestampTouch(memberKey, profName)
+    -- Rate limit: only broadcast once per hour per profession to avoid spamming
+    -- the DR when the player opens a profession window repeatedly.
+    self._lastTouchBroadcast = self._lastTouchBroadcast or {}
+    local last = self._lastTouchBroadcast[profName]
+    if last and (time() - last) < 3600 then
+        GuildCrafts:Debug("DELTA_UPDATE (touch) rate-limited for", profName)
+        return
+    end
+    self._lastTouchBroadcast[profName] = time()
+    local gdb = GuildCrafts.Data:GetGuildDB()
+    local entry = gdb and gdb[memberKey]
+    self:SendMessage(MSG_DELTA_UPDATE, {
+        type       = "touch",
+        member     = memberKey,
+        profession = profName,
+        lastUpdate = entry and entry.lastUpdate or time(),
+    }, "GUILD", nil, PRIO_NORMAL)
+    GuildCrafts:Debug("Broadcast DELTA_UPDATE (touch) for", memberKey, profName)
+end
+
 function Comms:HandleDeltaUpdate(payload, sender)
     if not payload.member then return end
     local playerKey = GuildCrafts.Data:GetPlayerKey()
@@ -796,6 +821,18 @@ function Comms:HandleDeltaUpdate(payload, sender)
                 recipeKey, recipeData, payload.lastUpdate)
         end
         GuildCrafts:Debug("DELTA_UPDATE (add) from", sender, "for", payload.member)
+
+    elseif payload.type == "touch" and payload.lastUpdate then
+        -- Lightweight timestamp bump — the sender has no new recipes but is still
+        -- active. Update lastUpdate so local pruning logic doesn't evict them.
+        local gdb = GuildCrafts.Data:GetGuildDB()
+        local entry = gdb and gdb[payload.member]
+        if entry and payload.lastUpdate > (entry.lastUpdate or 0) then
+            entry.lastUpdate = payload.lastUpdate
+        end
+        GuildCrafts:Debug("DELTA_UPDATE (touch) from", sender, "for", payload.member)
+        -- No recipe data changed; skip UI refresh.
+        return
 
     elseif payload.type == "remove_profession" then
         -- Remove entire profession

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.3.6a"
+GuildCrafts.DISPLAY_VERSION = "1.3.7"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -43,6 +43,7 @@ local tonumber = tonumber
 local STALE_DISPLAY_THRESHOLD   = 30 * 24 * 3600  -- show [Nd ago] tag; CountStaleMembers baseline
 local EX_GUILD_GRACE_PERIOD     =  7 * 24 * 3600  -- prune ex-members after 7 days absent
 local INACTIVE_MEMBER_THRESHOLD = 45 * 24 * 3600  -- prune still-in-guild members with no scan in 45 days
+local TOUCH_BROADCAST_THRESHOLD = 25 * 24 * 3600  -- broadcast timestamp touch only when data is 25+ days old
 
 -- TBC crafting professions we track (canonical English keys)
 local TRACKED_PROFESSIONS = {
@@ -899,6 +900,8 @@ function Data:ScanTradeSkill()
     local playerKey = self:GetPlayerKey()
     local entry = self:GetMemberEntry(playerKey, true)
     if not entry then return end
+    -- Capture age before any processing so backfill cannot poison the threshold check.
+    local ageAtScanStart = entry.lastUpdate and (time() - entry.lastUpdate) or math.huge
     if not entry.professions[profName] then
         entry.professions[profName] = { recipes = {} }
     end
@@ -984,6 +987,16 @@ function Data:ScanTradeSkill()
             GuildCrafts.Tooltip:InvalidateIndex()
         end
     else
+        -- Always refresh lastUpdate when a profession window is opened, even if
+        -- nothing changed. Without this, users who have learned all recipes will
+        -- never advance their timestamp and will hit the stale-data warning.
+        entry.lastUpdate = time()
+        -- Only broadcast the timestamp bump when data is approaching the prune
+        -- threshold (25–45 days). Avoids spamming the DR on every profession open.
+        -- Use ageAtScanStart (captured before backfill) so backfill cannot reset the age.
+        if ageAtScanStart >= TOUCH_BROADCAST_THRESHOLD and GuildCrafts.Comms and GuildCrafts.Comms.BroadcastTimestampTouch then
+            GuildCrafts.Comms:BroadcastTimestampTouch(playerKey, profName)
+        end
         GuildCrafts:Debug("Scanned " .. profName .. ": no new recipes.")
     end
 
@@ -1071,6 +1084,8 @@ function Data:ScanCraft()
     local playerKey = self:GetPlayerKey()
     local entry = self:GetMemberEntry(playerKey, true)
     if not entry then return end
+    -- Capture age before any processing so backfill cannot poison the threshold check.
+    local ageAtScanStart = entry.lastUpdate and (time() - entry.lastUpdate) or math.huge
     if not entry.professions[profName] then
         entry.professions[profName] = { recipes = {} }
     end
@@ -1158,6 +1173,16 @@ function Data:ScanCraft()
             GuildCrafts.Tooltip:InvalidateIndex()
         end
     else
+        -- Always refresh lastUpdate when a profession window is opened, even if
+        -- nothing changed. Without this, users who have learned all recipes will
+        -- never advance their timestamp and will hit the stale-data warning.
+        entry.lastUpdate = time()
+        -- Only broadcast the timestamp bump when data is approaching the prune
+        -- threshold (25–45 days). Avoids spamming the DR on every profession open.
+        -- Use ageAtScanStart (captured before backfill) so backfill cannot reset the age.
+        if ageAtScanStart >= TOUCH_BROADCAST_THRESHOLD and GuildCrafts.Comms and GuildCrafts.Comms.BroadcastTimestampTouch then
+            GuildCrafts.Comms:BroadcastTimestampTouch(playerKey, profName)
+        end
         GuildCrafts:Debug("Scanned " .. profName .. ": no new recipes.")
     end
 

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.3.6a
+## Version: 1.3.7
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild


### PR DESCRIPTION
## Problem

Players who had learned all recipes in a profession would never have their `lastUpdate` timestamp advanced when opening profession windows. This caused the 30-day stale-data warning to fire even for active players, and — more critically — peers and the DR would eventually prune the player's data at 45 days.

## Changes

### `Data.lua`
- `ScanTradeSkill` and `ScanCraft` now always update `lastUpdate` when a profession window is opened, even when no new recipes are found
- Age is captured **before** any backfill or skill-level update runs, so a backfill cannot reset the age and suppress a legitimate touch broadcast
- Added `TOUCH_BROADCAST_THRESHOLD` constant (25 days) — touch broadcasts only fire when data is 25–45 days old, avoiding traffic during normal play

### `Comms.lua`
- Added `BroadcastTimestampTouch` — sends a lightweight `DELTA_UPDATE {type="touch"}` carrying only the updated `lastUpdate`
- Rate-limited to once per hour per profession via `_lastTouchBroadcast` table
- `HandleDeltaUpdate` now handles `type="touch"`: updates the peer's `lastUpdate` if newer, then **returns early** to skip `UI:Refresh()` since no recipe data changed

### `CHANGELOG.md` / `.toc` / `Core.lua`
- Version bumped to **1.3.7**