### PR TITLE
fix: clear syncProcessing only after last chunk, not after first (v1.3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,42 @@
-    # Changelog
+        # Changelog
 
-## 1.3.7 — 2026-04-21
+    ## 1.3.8 — 2026-04-28
 
-### Fixes
+    ### Fixes
 
-- **Stale-data warning never resolved when all recipes were already learned** — opening a profession window only updated your sync timestamp when new recipes or a skill level change were detected. Players who had learned everything would keep aging toward the prune threshold even while actively playing. The addon now always refreshes the timestamp when a profession window is opened, regardless of whether anything changed.
+    - **Sync queue could fire while previous sync chunks were still in-flight** — the DR marks itself as "processing" while sending a chunked `SYNC_RESPONSE`, but because chunk delivery is timer-based (1 chunk/second), the processing flag was cleared immediately after the first chunk was sent rather than after the last. In guilds with burst logins this allowed a queued `SYNC_REQUEST` to start a new sync before the previous one finished, potentially launching multiple interleaved chunk timer chains and hitting chat throttle limits. The processing flag is now cleared in the last chunk's timer callback via an `onComplete` hook on `SendChunked`.
 
-- **Peers and the Designated Requester could prune an active player** — because the timestamp update was local-only, other guild members' clients (and the DR) still saw the old timestamp and would eventually prune the entry at 45 days. The addon now broadcasts a lightweight `DELTA_UPDATE (touch)` message to the guild when data is 25–45 days old, so all peers stay in sync. To avoid unnecessary traffic the broadcast is rate-limited to once per hour per profession.
+    ---
 
----
+    ## 1.3.7 — 2026-04-21
 
-## 1.3.6a — 2026-04-15
+    ### Fixes
 
-### Fixes
+    - **Stale-data warning never resolved when all recipes were already learned** — opening a profession window only updated your sync timestamp when new recipes or a skill level change were detected. Players who had learned everything would keep aging toward the prune threshold even while actively playing. The addon now always refreshes the timestamp when a profession window is opened, regardless of whether anything changed.
 
-- **Recipe name overlap in Recipes view** — the 1.3.6 fix only applied to search results; the Recipes tab (browsing all guild recipes for a profession) used a separate render path with the same undersized margin. Applied the same 205 px right margin to `ShowRecipesView` so long Enchanting recipe names no longer overlap the crafter column in either view
+    - **Peers and the Designated Requester could prune an active player** — because the timestamp update was local-only, other guild members' clients (and the DR) still saw the old timestamp and would eventually prune the entry at 45 days. The addon now broadcasts a lightweight `DELTA_UPDATE (touch)` message to the guild when data is 25–45 days old, so all peers stay in sync. To avoid unnecessary traffic the broadcast is rate-limited to once per hour per profession.
 
----
+    ---
 
-## 1.3.6 — 2026-04-15
+    ## 1.3.6a — 2026-04-15
 
-### Fixes
+    ### Fixes
 
-- **Recipe name overlap with crafter column** — long recipe names (most visible in Enchanting) could overlap the crafter text on the right side of recipe rows. Increased the right margin reserved for the crafter column from 175 px to 205 px to give the full button + crafter text area proper clearance
+    - **Recipe name overlap in Recipes view** — the 1.3.6 fix only applied to search results; the Recipes tab (browsing all guild recipes for a profession) used a separate render path with the same undersized margin. Applied the same 205 px right margin to `ShowRecipesView` so long Enchanting recipe names no longer overlap the crafter column in either view
 
----
+    ---
 
-## 1.3.5 — 2026-04-11
+    ## 1.3.6 — 2026-04-15
 
-### Fixes
+    ### Fixes
+
+    - **Recipe name overlap with crafter column** — long recipe names (most visible in Enchanting) could overlap the crafter text on the right side of recipe rows. Increased the right margin reserved for the crafter column from 175 px to 205 px to give the full button + crafter text area proper clearance
+
+    ---
+
+    ## 1.3.5 — 2026-04-11
+
+    ### Fixes
 
     - **GuildCrafts window no longer covers other windows** — the main frame was set to `HIGH` strata, which placed it on top of Blizzard UI panels including the tradeskill window, bags, and character sheet. Changed to `MEDIUM` so it behaves like a normal addon window and yields to game UI frames
 

--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -582,8 +582,19 @@ function Comms:ProcessSyncRequest(requester, incomingVector)
     local sendCount = 0
     for _ in pairs(toSend) do sendCount = sendCount + 1 end
 
+    -- Callback fired once all chunks have been sent (or immediately if no chunks).
+    -- Clears syncProcessing so the queue can proceed. Defined before SendChunked so
+    -- the closure is available regardless of the code path taken below.
+    local function onSendComplete()
+        self.syncProcessing = false
+        self:ProcessNextSyncQueue()
+    end
+
     if sendCount > 0 then
-        self:SendChunked(MSG_SYNC_RESPONSE, toSend, requester, sendCount)
+        -- Pass onComplete so syncProcessing is cleared only after the last chunk
+        -- fires, not immediately after SendChunked returns. Without this, a queued
+        -- SYNC_REQUEST could start while previous chunks are still in-flight.
+        self:SendChunked(MSG_SYNC_RESPONSE, toSend, requester, sendCount, onSendComplete)
     else
         -- Always send at least an empty SYNC_RESPONSE so the requester
         -- knows we heard them and can stop waiting (otherwise they time out).
@@ -606,9 +617,11 @@ function Comms:ProcessSyncRequest(requester, incomingVector)
         GuildCrafts:Debug("Sync with", requester, "— already converged.")
     end
 
-    -- Mark processing complete and check queue
-    self.syncProcessing = false
-    self:ProcessNextSyncQueue()
+    -- If there were no chunks to send, mark complete immediately.
+    -- Otherwise onSendComplete will fire after the last chunk.
+    if sendCount == 0 then
+        onSendComplete()
+    end
 end
 
 function Comms:ProcessNextSyncQueue()
@@ -868,7 +881,8 @@ end
 
 --- Send a member data table in chunks of SYNC_CHUNK_SIZE.
 --- Each chunk is sent after a SYNC_CHUNK_DELAY to avoid burst lag.
-function Comms:SendChunked(msgType, memberData, target, totalCount)
+--- onComplete is an optional callback fired after the last chunk is sent.
+function Comms:SendChunked(msgType, memberData, target, totalCount, onComplete)
     local keys = {}
     for k in pairs(memberData) do
         keys[#keys + 1] = k
@@ -898,6 +912,9 @@ function Comms:SendChunked(msgType, memberData, target, totalCount)
             self:ScheduleTimer(function()
                 sendChunk(chunkIndex + 1, nextStart)
             end, SYNC_CHUNK_DELAY)
+        elseif onComplete then
+            -- Last chunk sent — notify caller
+            onComplete()
         end
     end
 

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.3.7"
+GuildCrafts.DISPLAY_VERSION = "1.3.8"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.3.7
+## Version: 1.3.8
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild


### PR DESCRIPTION
## Problem

`SendChunked` delivers chunks via `ScheduleTimer` at 1-second intervals, but `ProcessSyncRequest` was clearing `syncProcessing = false` synchronously after calling `SendChunked` — i.e. after chunk 1, while chunks 2..N were still queued in timers.

A queued `SYNC_REQUEST` could then enter `ProcessSyncRequest` immediately, launching a second independent chunk timer chain concurrently with the first. On large guilds with burst logins this risked interleaved whisper traffic hitting chat throttle limits and causing `SYNC_TIMEOUT` retry storms.

## Fix

Added an optional `onComplete` callback parameter to `SendChunked`. It fires:
- After the last `ScheduleTimer` callback when `totalChunks > 1`
- Inline (no timer) when `totalChunks == 1`

`ProcessSyncRequest` passes `onComplete` to clear `syncProcessing` and drain the sync queue only once all chunks have been sent. The no-chunks path (empty `SYNC_RESPONSE`) calls `onComplete` immediately as before.

No changes to `SYNC_PUSH` path — `HandleSyncPull` uses `SendChunked` without `onComplete` which is correct (it doesn't gate `syncProcessing`).