### PR TITLE
feat: Patch 1 — SyncPausePolicy + Partial Scan Protection (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,380 +1,390 @@
-        # Changelog
+# Changelog
 
-    ## 1.3.8 — 2026-04-28
+## 1.4.0 — 2026-05-15
 
-    ### Fixes
+### New features
 
-    - **Sync queue could fire while previous sync chunks were still in-flight** — the DR marks itself as "processing" while sending a chunked `SYNC_RESPONSE`, but because chunk delivery is timer-based (1 chunk/second), the processing flag was cleared immediately after the first chunk was sent rather than after the last. In guilds with burst logins this allowed a queued `SYNC_REQUEST` to start a new sync before the previous one finished, potentially launching multiple interleaved chunk timer chains and hitting chat throttle limits. The processing flag is now cleared in the last chunk's timer callback via an `onComplete` hook on `SendChunked`.
+- **SyncPausePolicy** — all outgoing sync traffic is now automatically suspended during combat, inside instances, and for a short grace period after zone transitions. This prevents addon messages from being dropped or contributing to chat throttle at exactly the moments when the client is busiest. Grace periods: 6 s after leaving combat, 12 s after a zone transition, 15 s after leaving an instance.
 
-    ---
+- **Partial scan protection** — opening a profession window that the API hasn't fully loaded yet can return far fewer recipes than you actually know. The addon now compares the scanned count against the stored count before writing; if the new data accounts for less than 50 % of what's already recorded, the write is skipped and a rescan is scheduled 2 s later. The same guard is applied to incoming sync data, preventing a peer's partial scan from overwriting your complete local copy.
 
-    ## 1.3.7 — 2026-04-21
+---
 
-    ### Fixes
+## 1.3.8 — 2026-04-28
 
-    - **Stale-data warning never resolved when all recipes were already learned** — opening a profession window only updated your sync timestamp when new recipes or a skill level change were detected. Players who had learned everything would keep aging toward the prune threshold even while actively playing. The addon now always refreshes the timestamp when a profession window is opened, regardless of whether anything changed.
+### Fixes
 
-    - **Peers and the Designated Requester could prune an active player** — because the timestamp update was local-only, other guild members' clients (and the DR) still saw the old timestamp and would eventually prune the entry at 45 days. The addon now broadcasts a lightweight `DELTA_UPDATE (touch)` message to the guild when data is 25–45 days old, so all peers stay in sync. To avoid unnecessary traffic the broadcast is rate-limited to once per hour per profession.
+- **Sync queue could fire while previous sync chunks were still in-flight** — the DR marks itself as "processing" while sending a chunked `SYNC_RESPONSE`, but because chunk delivery is timer-based (1 chunk/second), the processing flag was cleared immediately after the first chunk was sent rather than after the last. In guilds with burst logins this allowed a queued `SYNC_REQUEST` to start a new sync before the previous one finished, potentially launching multiple interleaved chunk timer chains and hitting chat throttle limits. The processing flag is now cleared in the last chunk's timer callback via an `onComplete` hook on `SendChunked`.
 
-    ---
+---
 
-    ## 1.3.6a — 2026-04-15
+## 1.3.7 — 2026-04-21
 
-    ### Fixes
+### Fixes
 
-    - **Recipe name overlap in Recipes view** — the 1.3.6 fix only applied to search results; the Recipes tab (browsing all guild recipes for a profession) used a separate render path with the same undersized margin. Applied the same 205 px right margin to `ShowRecipesView` so long Enchanting recipe names no longer overlap the crafter column in either view
+- **Stale-data warning never resolved when all recipes were already learned** — opening a profession window only updated your sync timestamp when new recipes or a skill level change were detected. Players who had learned everything would keep aging toward the prune threshold even while actively playing. The addon now always refreshes the timestamp when a profession window is opened, regardless of whether anything changed.
 
-    ---
+- **Peers and the Designated Requester could prune an active player** — because the timestamp update was local-only, other guild members' clients (and the DR) still saw the old timestamp and would eventually prune the entry at 45 days. The addon now broadcasts a lightweight `DELTA_UPDATE (touch)` message to the guild when data is 25–45 days old, so all peers stay in sync. To avoid unnecessary traffic the broadcast is rate-limited to once per hour per profession.
 
-    ## 1.3.6 — 2026-04-15
+---
 
-    ### Fixes
+## 1.3.6a — 2026-04-15
 
-    - **Recipe name overlap with crafter column** — long recipe names (most visible in Enchanting) could overlap the crafter text on the right side of recipe rows. Increased the right margin reserved for the crafter column from 175 px to 205 px to give the full button + crafter text area proper clearance
+### Fixes
 
-    ---
+- **Recipe name overlap in Recipes view** — the 1.3.6 fix only applied to search results; the Recipes tab (browsing all guild recipes for a profession) used a separate render path with the same undersized margin. Applied the same 205 px right margin to `ShowRecipesView` so long Enchanting recipe names no longer overlap the crafter column in either view
 
-    ## 1.3.5 — 2026-04-11
+---
 
-    ### Fixes
+## 1.3.6 — 2026-04-15
 
-    - **GuildCrafts window no longer covers other windows** — the main frame was set to `HIGH` strata, which placed it on top of Blizzard UI panels including the tradeskill window, bags, and character sheet. Changed to `MEDIUM` so it behaves like a normal addon window and yields to game UI frames
+### Fixes
 
-    ---
+- **Recipe name overlap with crafter column** — long recipe names (most visible in Enchanting) could overlap the crafter text on the right side of recipe rows. Increased the right margin reserved for the crafter column from 175 px to 205 px to give the full button + crafter text area proper clearance
 
-    ## 1.3.4 — 2026-04-05
+---
 
-    ### Improvements
+## 1.3.5 — 2026-04-11
 
-    - **Specialisation tags in item tooltips** — when hovering an item that guild members can craft, any crafter with a profession specialisation now shows it inline: e.g. `PlayerA — Alchemy [Elixir Master]`. Applies to all TBC specs: Alchemy (Potion/Elixir/Transmutation Master), Blacksmithing, Engineering, Leatherworking, and Tailoring. Offline crafters show the spec in grey
+### Fixes
 
-    ### Fixes
+- **GuildCrafts window no longer covers other windows** — the main frame was set to `HIGH` strata, which placed it on top of Blizzard UI panels including the tradeskill window, bags, and character sheet. Changed to `MEDIUM` so it behaves like a normal addon window and yields to game UI frames
 
-    - **LibDBIcon-1.0 minimap button** — replaced the custom minimap button implementation with the standard LibDBIcon-1.0 library. Leatrix Plus no longer warns about a non-standard minimap button; the button also works correctly with SexyMap and any other minimap manager automatically. Drag-to-position and `/gc minimap` toggle are unchanged
+---
 
-    ---
+## 1.3.4 — 2026-04-05
 
-    ## 1.3.3 — 2026-03-28
+### Improvements
 
-    ### Improvements
+- **Specialisation tags in item tooltips** — when hovering an item that guild members can craft, any crafter with a profession specialisation now shows it inline: e.g. `PlayerA — Alchemy [Elixir Master]`. Applies to all TBC specs: Alchemy (Potion/Elixir/Transmutation Master), Blacksmithing, Engineering, Leatherworking, and Tailoring. Offline crafters show the spec in grey
 
-    - **Sync burst reduction in large guilds** — contributed by [@shockedarmor](https://github.com/shockedarmor) (PR #72). When multiple guild members log in or are discovered within a short window, the old code fired one `SYNC_REQUEST` per discovery almost simultaneously. All three re-sync scheduling sites (`HandleHello`, `TouchAddonUser`, `RecomputeElection`) now share a single debounce timer: each new discovery cancels and reschedules a sync 10 seconds after the *last* event, collapsing a burst of discoveries into one request. Tested in a live 25-man raid with 30 addon users syncing simultaneously — no lag spikes and full convergence within a couple of minutes
+### Fixes
 
-    - **Chunked sync is now paced** — `SendChunked` now sends one chunk per second via a timer instead of a tight synchronous loop, preventing a burst of whisper messages hitting all clients at once during a large sync
+- **LibDBIcon-1.0 minimap button** — replaced the custom minimap button implementation with the standard LibDBIcon-1.0 library. Leatrix Plus no longer warns about a non-standard minimap button; the button also works correctly with SexyMap and any other minimap manager automatically. Drag-to-position and `/gc minimap` toggle are unchanged
 
-    - **Sync timing adjustments** — `SYNC_DELAY` raised from 5 s to 15 s (pushes the initial sync past the worst of login lag); `SYNC_TIMEOUT` raised from 30 s to 120 s (accommodates the slower paced chunk cadence)
+---
 
-    ---
+## 1.3.3 — 2026-03-28
 
-    ## 1.3.2 — 2026-03-26
+### Improvements
 
-    ### Fixes
+- **Sync burst reduction in large guilds** — contributed by [@shockedarmor](https://github.com/shockedarmor) (PR #72). When multiple guild members log in or are discovered within a short window, the old code fired one `SYNC_REQUEST` per discovery almost simultaneously. All three re-sync scheduling sites (`HandleHello`, `TouchAddonUser`, `RecomputeElection`) now share a single debounce timer: each new discovery cancels and reschedules a sync 10 seconds after the *last* event, collapsing a burst of discoveries into one request. Tested in a live 25-man raid with 30 addon users syncing simultaneously — no lag spikes and full convergence within a couple of minutes
 
-    - **Guild chat message truncation** — when clicking the `[>]` post button for a recipe with many crafters, the crafter list plus the ` — /gc to browse` trailer could exceed WoW's 255-byte message limit by up to 3 bytes, silently cutting off the end of the line. `FormatCraftersLine` now accepts an optional `extraReserve` parameter so callers can account for any suffix they append; `PostCraftersToGuildChat` passes the exact byte-length of its trailer
+- **Chunked sync is now paced** — `SendChunked` now sends one chunk per second via a timer instead of a tight synchronous loop, preventing a burst of whisper messages hitting all clients at once during a large sync
 
-    - **`!gc` overflow line display** — when a `!gc` query matched more than 3 recipes, the overflow notice rendered as `[GuildCrafts] ...3 more result(s)` (number ran directly into the ellipsis). Changed to `[GuildCrafts] +3 more result(s) — /gc to browse`
+- **Sync timing adjustments** — `SYNC_DELAY` raised from 5 s to 15 s (pushes the initial sync past the worst of login lag); `SYNC_TIMEOUT` raised from 30 s to 120 s (accommodates the slower paced chunk cadence)
 
-    ---
+---
 
-    ## 1.3.1 — 2026-03-22
+## 1.3.2 — 2026-03-26
 
-    ### Fixes
+### Fixes
 
-    - **`!gc` enchant link lookup** — shift-clicking an enchant spell link into guild chat (e.g. `!gc [Enchanting: Enchant Bracer - Spellpower]`) now correctly strips the leading `Profession: ` prefix before searching. Previously the prefix caused a false "No guild crafter found" even when crafters existed
+- **Guild chat message truncation** — when clicking the `[>]` post button for a recipe with many crafters, the crafter list plus the ` — /gc to browse` trailer could exceed WoW's 255-byte message limit by up to 3 bytes, silently cutting off the end of the line. `FormatCraftersLine` now accepts an optional `extraReserve` parameter so callers can account for any suffix they append; `PostCraftersToGuildChat` passes the exact byte-length of its trailer
 
-    ### Improvements
+- **`!gc` overflow line display** — when a `!gc` query matched more than 3 recipes, the overflow notice rendered as `[GuildCrafts] ...3 more result(s)` (number ran directly into the ellipsis). Changed to `[GuildCrafts] +3 more result(s) — /gc to browse`
 
-    - **Locale-independent link lookup** — when a `!gc` query contains a shift-clicked hyperlink, the numeric item/spell ID is extracted and used for an exact key-based DB lookup before falling back to text search. A German DR can now answer an English player's shift-clicked link (and vice-versa) regardless of client language
+---
 
-    ### Housekeeping
+## 1.3.1 — 2026-03-22
 
-    - **Removed simulation system** — the `/gc sim` debug subsystem (250+ lines) has been removed. It was a development-era tool no longer needed for a shipped addon
-    - **Dead code cleanup** — removed 5 unused functions across Data, Comms, and Favorites modules (–304 lines total)
+### Fixes
 
-    ---
+- **`!gc` enchant link lookup** — shift-clicking an enchant spell link into guild chat (e.g. `!gc [Enchanting: Enchant Bracer - Spellpower]`) now correctly strips the leading `Profession: ` prefix before searching. Previously the prefix caused a false "No guild crafter found" even when crafters existed
 
-    ## 1.3.0 — 2026-03-22
+### Improvements
 
-    ### Improvements
+- **Locale-independent link lookup** — when a `!gc` query contains a shift-clicked hyperlink, the numeric item/spell ID is extracted and used for an exact key-based DB lookup before falling back to text search. A German DR can now answer an English player's shift-clicked link (and vice-versa) regardless of client language
 
-    - **Ghost member auto-prune** — members who are still in the guild but haven't scanned their professions in 45 days are now automatically removed from the guild database. Previously only ex-guild members were pruned; a still-in-guild member who uninstalled GuildCrafts would accumulate an ever-staler entry indefinitely
-    - **Ex-guild grace period reduced: 30d → 7d** — someone who leaves the guild is immediately irrelevant; their entry is now gone within a week instead of a month
-    - **Login stale-data warning** — if your own profession data is more than 30 days old, a one-time amber message appears in chat on login reminding you to open your profession windows to resync. Fires once per session only
-    - **Smarter login prompt** — the blanket "open profession windows" message is replaced with a targeted warning that lists only the specific professions you have but haven't scanned yet. Herbalism and Skinning are excluded (no recipes to scan). No message is shown if all professions are already synced
-    - **Legacy entry cleanup** — entries from early addon versions that were never assigned a scan timestamp (`lastUpdate` nil or 0) are now pruned on the next roster cycle. Active members who open a profession window get a fresh entry immediately
-    - **Silent load** — the startup chat message ("v1.x loaded…") has been removed. The addon only speaks when there is something actionable to say
+### Housekeeping
 
-    ---
+- **Removed simulation system** — the `/gc sim` debug subsystem (250+ lines) has been removed. It was a development-era tool no longer needed for a shipped addon
+- **Dead code cleanup** — removed 5 unused functions across Data, Comms, and Favorites modules (–304 lines total)
 
-    ## 1.2.5 — 2026-03-20
+---
 
-    ### Improvements
+## 1.3.0 — 2026-03-22
 
-    - **Deferred tooltip index rebuild** — the reverse-lookup index used by item tooltips is no longer rebuilt synchronously during a hover event. `InvalidateIndex()` now schedules a 2-second deferred rebuild via `C_Timer.After`; hover events always use the most recently built index. This eliminates frame hitches on first hover after a sync burst in large guilds
-    - **Richer sync status tooltip** — hovering the sync dot in the title bar now shows two additional lines: _Last synced_ (time since the last completed `SYNC_RESPONSE` transaction this session, or "not yet this session" for a DR that has not synced with anyone) and _Stale members (30d+)_ (count of member entries older than 30 days, shown in amber only when non-zero)
+### Improvements
 
-    ---
+- **Ghost member auto-prune** — members who are still in the guild but haven't scanned their professions in 45 days are now automatically removed from the guild database. Previously only ex-guild members were pruned; a still-in-guild member who uninstalled GuildCrafts would accumulate an ever-staler entry indefinitely
+- **Ex-guild grace period reduced: 30d → 7d** — someone who leaves the guild is immediately irrelevant; their entry is now gone within a week instead of a month
+- **Login stale-data warning** — if your own profession data is more than 30 days old, a one-time amber message appears in chat on login reminding you to open your profession windows to resync. Fires once per session only
+- **Smarter login prompt** — the blanket "open profession windows" message is replaced with a targeted warning that lists only the specific professions you have but haven't scanned yet. Herbalism and Skinning are excluded (no recipes to scan). No message is shown if all professions are already synced
+- **Legacy entry cleanup** — entries from early addon versions that were never assigned a scan timestamp (`lastUpdate` nil or 0) are now pruned on the next roster cycle. Active members who open a profession window get a fresh entry immediately
+- **Silent load** — the startup chat message ("v1.x loaded…") has been removed. The addon only speaks when there is something actionable to say
 
-    ## 1.2.4b — 2026-03-19
+---
 
-    ### Fixes
+## 1.2.5 — 2026-03-20
 
-    - **Fixed Enchanting fallback key collision risk** — the last-resort recipe key for enchants that yield neither an itemID nor a spellID was derived from a plain `craftName` hash in the range −1,000,000 to −2,000,000. This shared the same modulo space across all enchant names and could silently overwrite one recipe with another. Fix: the input is now namespaced (`"enc:" .. craftName`) and the hash is placed in a dedicated range below −2,000,000, separated from real spellID-based keys. Collision risk is reduced; the fallback path should never fire for any known TBC enchant
+### Improvements
 
-    ---
+- **Deferred tooltip index rebuild** — the reverse-lookup index used by item tooltips is no longer rebuilt synchronously during a hover event. `InvalidateIndex()` now schedules a 2-second deferred rebuild via `C_Timer.After`; hover events always use the most recently built index. This eliminates frame hitches on first hover after a sync burst in large guilds
+- **Richer sync status tooltip** — hovering the sync dot in the title bar now shows two additional lines: _Last synced_ (time since the last completed `SYNC_RESPONSE` transaction this session, or "not yet this session" for a DR that has not synced with anyone) and _Stale members (30d+)_ (count of member entries older than 30 days, shown in amber only when non-zero)
 
-    ## 1.2.4a — 2026-03-18
+---
 
-    ### Fixes
+## 1.2.4b — 2026-03-19
 
-    - **Fixed role change log showing wrong transition** — when a node stepped down from DR after receiving a higher-term heartbeat, the debug log showed `OTHER → BDR` instead of `DR → BDR`. Root cause: `myRole` was reset to `OTHER` in the generic message handler before `RecomputeElection()` ran, so `oldRole` was always `OTHER`
-    - **Fixed sync panel showing stale DR** — `RecomputeElection()` was called in the generic message handler before `HandleHeartbeat` had registered the sender in `addonUsers`, so the election ran with an incomplete peer list and `currentDR` came out wrong. Fix: removed the premature role reset and election call from the generic handler; `HandleHeartbeat` now always calls `RecomputeElection()` and updates the sync indicator after registering the sender
+### Fixes
 
-    ---
+- **Fixed Enchanting fallback key collision risk** — the last-resort recipe key for enchants that yield neither an itemID nor a spellID was derived from a plain `craftName` hash in the range −1,000,000 to −2,000,000. This shared the same modulo space across all enchant names and could silently overwrite one recipe with another. Fix: the input is now namespaced (`"enc:" .. craftName`) and the hash is placed in a dedicated range below −2,000,000, separated from real spellID-based keys. Collision risk is reduced; the fallback path should never fire for any known TBC enchant
 
-    ## 1.2.4 — Secondary Professions — 2026-03-17
+---
 
-    ### New Features
+## 1.2.4a — 2026-03-18
 
-    - **Mining (Smelting), Herbalism, and Skinning now tracked** — gathering professions appear in the profession browser alongside crafting professions. Skill levels are tracked and synced; member counts show in the left panel the same way as any other profession
-    - **Smelting recipes tracked under Mining** — the Smelting tradeskill window fires `TRADE_SKILL_SHOW` exactly like any crafting profession, so Smelting recipes are scanned and stored under the Mining entry. 
-    - **Secondary profession divider in left panel** — a thin separator divides the crafting professions (Alchemy, Blacksmithing, Enchanting, Engineering, Jewelcrafting, Leatherworking, Tailoring) from the secondary group (Mining, Herbalism, Skinning, Cooking) in the left navigation panel
-    - **Cooking moved to secondary group** — Cooking now appears below the divider with the other secondary professions
-    - **Gathering profession detail panel** — clicking a Herbalism or Skinning member shows their name, skill level, and last-scanned timestamp at the top, with a clear `Herbalism is a gathering profession. No recipes to display.` note below instead of the generic empty-state message
+### Fixes
 
-    ### Fixes
+- **Fixed role change log showing wrong transition** — when a node stepped down from DR after receiving a higher-term heartbeat, the debug log showed `OTHER → BDR` instead of `DR → BDR`. Root cause: `myRole` was reset to `OTHER` in the generic message handler before `RecomputeElection()` ran, so `oldRole` was always `OTHER`
+- **Fixed sync panel showing stale DR** — `RecomputeElection()` was called in the generic message handler before `HandleHeartbeat` had registered the sender in `addonUsers`, so the election ran with an incomplete peer list and `currentDR` came out wrong. Fix: removed the premature role reset and election call from the generic handler; `HandleHeartbeat` now always calls `RecomputeElection()` and updates the sync indicator after registering the sender
 
-    - **Fixed DR term oscillation** — two online addon users could endlessly leapfrog each other's DR authority terms (1472 → 1473 → 1474...) spamming the debug window. Root cause: `RecomputeElection()` was called before the heartbeat sender was registered in the peer list, so the stepping-down node re-elected itself immediately. Fix: register the peer first, then compute election once with complete information 
+---
 
-    ---
+## 1.2.4 — Secondary Professions — 2026-03-17
 
-    ## 1.2.3a — 2026-03-16
+### New Features
 
-    ### Fixes
+- **Mining (Smelting), Herbalism, and Skinning now tracked** — gathering professions appear in the profession browser alongside crafting professions. Skill levels are tracked and synced; member counts show in the left panel the same way as any other profession
+- **Smelting recipes tracked under Mining** — the Smelting tradeskill window fires `TRADE_SKILL_SHOW` exactly like any crafting profession, so Smelting recipes are scanned and stored under the Mining entry. 
+- **Secondary profession divider in left panel** — a thin separator divides the crafting professions (Alchemy, Blacksmithing, Enchanting, Engineering, Jewelcrafting, Leatherworking, Tailoring) from the secondary group (Mining, Herbalism, Skinning, Cooking) in the left navigation panel
+- **Cooking moved to secondary group** — Cooking now appears below the divider with the other secondary professions
+- **Gathering profession detail panel** — clicking a Herbalism or Skinning member shows their name, skill level, and last-scanned timestamp at the top, with a clear `Herbalism is a gathering profession. No recipes to display.` note below instead of the generic empty-state message
 
-    - **Fixed `!gc` double-response when DR is inside an instance** — when the Designated Router enters a battleground or dungeon, heartbeats stop crossing the instance boundary. After 3 minutes the BDR is promoted to DR outside, but the original DR is still alive and also responding to `!gc` queries — causing two replies in guild chat. The fix: a DR inside an instance now treats itself as a regular node for `!gc` purposes (12–20 s delay with jitter). The outside DR/BDR responds first; the in-instance DR sees the `[GuildCrafts]` echo in guild chat and cancels its pending reply. When the DR leaves the instance it broadcasts HELLO, roles re-converge within seconds, and it reclaims the DR role normally
+### Fixes
 
-    ---
+- **Fixed DR term oscillation** — two online addon users could endlessly leapfrog each other's DR authority terms (1472 → 1473 → 1474...) spamming the debug window. Root cause: `RecomputeElection()` was called before the heartbeat sender was registered in the peer list, so the stepping-down node re-elected itself immediately. Fix: register the peer first, then compute election once with complete information 
 
-    ## 1.2.3 — Whisper & UI Polish — 2026-03-16
+---
 
-    ### New Features
+## 1.2.3a — 2026-03-16
 
-    - **`[W]` whisper button** — each recipe row now has a `[W]` button to the left of `[>]`. Clicking it opens the chat edit box pre-filled with `/w CharName Can you craft X for me?`. If there is only one non-self crafter the whisper opens directly; if there are multiple, a small dropdown picker appears (online crafters shown in green, offline in grey). The button is hidden when you are the only known crafter
+### Fixes
 
-    - **Bottom bar with `[Online]` and `[Tooltip]` toggles** — the cryptic `O` dot has been replaced by proper labelled buttons in a thin bar at the bottom of the window. `[Online]` filters the crafter list to online members; `[Tooltip]` controls whether guild crafters are injected into hover tooltips. Both buttons glow yellow when active and dim when inactive, matching the existing `[Vanilla]` / `[TBC]` style
+- **Fixed `!gc` double-response when DR is inside an instance** — when the Designated Router enters a battleground or dungeon, heartbeats stop crossing the instance boundary. After 3 minutes the BDR is promoted to DR outside, but the original DR is still alive and also responding to `!gc` queries — causing two replies in guild chat. The fix: a DR inside an instance now treats itself as a regular node for `!gc` purposes (12–20 s delay with jitter). The outside DR/BDR responds first; the in-instance DR sees the `[GuildCrafts]` echo in guild chat and cancels its pending reply. When the DR leaves the instance it broadcasts HELLO, roles re-converge within seconds, and it reclaims the DR role normally
 
-    - **Tooltip crafters toggle** — the new `[Tooltip]` button lets you disable the tooltip crafter injection entirely. Useful in large guilds where popular items (flasks, enchants) generate very long tooltips. Off means no crafter section is shown at all; the setting persists across sessions
+---
 
-    - **Three-state online indicator** — the `O` dot next to each member name is now colour-coded with three states: **green** = online and GuildCrafts is active; **yellow** = online but GuildCrafts not detected (addon may be uninstalled); **grey** = offline. Hovering the dot shows a tooltip explaining the state
+## 1.2.3 — Whisper & UI Polish — 2026-03-16
 
-    ### Fixes
+### New Features
 
-    - **Cooking now appears in the profession list** — Cooking was tracked and synced correctly but was missing from the profession browser due to a hardcoded list that omitted it
-    - **Cooking now has a profession icon** — the bread/food icon is shown next to Cooking in the profession list, matching all other professions
-    - **Sync dot now updates correctly for the DR** — the Designated Router never receives a `SYNC_RESPONSE`, so the sync indicator was stuck on red even when other addon users were online. The dot now updates immediately when new peers are discovered via HELLO or heartbeat
-    - **Sync dot now updates on roster change** — the online indicator cross-checks `addonUsers` against the guild roster cache; it now re-evaluates whenever the roster rebuilds
-    - **Bottom bar buttons no longer overlap the resize grip** — the bar's right edge is offset far enough from the corner that it no longer touches the resize dragger
-    - **Fixed instances causing false DR eviction** — GUILD addon messages are not delivered inside instances and arenas. The DR heartbeat watchdog now pauses eviction while the player is in an instance, preventing a false re-election every 3 minutes when the DR zones in
+- **`[W]` whisper button** — each recipe row now has a `[W]` button to the left of `[>]`. Clicking it opens the chat edit box pre-filled with `/w CharName Can you craft X for me?`. If there is only one non-self crafter the whisper opens directly; if there are multiple, a small dropdown picker appears (online crafters shown in green, offline in grey). The button is hidden when you are the only known crafter
 
-    ### Removed
+- **Bottom bar with `[Online]` and `[Tooltip]` toggles** — the cryptic `O` dot has been replaced by proper labelled buttons in a thin bar at the bottom of the window. `[Online]` filters the crafter list to online members; `[Tooltip]` controls whether guild crafters are injected into hover tooltips. Both buttons glow yellow when active and dim when inactive, matching the existing `[Vanilla]` / `[TBC]` style
 
-    - **Craft request protocol** — the peer-to-peer craft request / accept / decline / complete flow (popup, comms commands, queue) has been removed. The `[W]` whisper button is the replacement workflow
+- **Tooltip crafters toggle** — the new `[Tooltip]` button lets you disable the tooltip crafter injection entirely. Useful in large guilds where popular items (flasks, enchants) generate very long tooltips. Off means no crafter section is shown at all; the setting persists across sessions
 
-    ---
+- **Three-state online indicator** — the `O` dot next to each member name is now colour-coded with three states: **green** = online and GuildCrafts is active; **yellow** = online but GuildCrafts not detected (addon may be uninstalled); **grey** = offline. Hovering the dot shows a tooltip explaining the state
 
-    ## 1.2.2 — Expansion Filter — 2026-03-13
+### Fixes
 
-    ### New Features
+- **Cooking now appears in the profession list** — Cooking was tracked and synced correctly but was missing from the profession browser due to a hardcoded list that omitted it
+- **Cooking now has a profession icon** — the bread/food icon is shown next to Cooking in the profession list, matching all other professions
+- **Sync dot now updates correctly for the DR** — the Designated Router never receives a `SYNC_RESPONSE`, so the sync indicator was stuck on red even when other addon users were online. The dot now updates immediately when new peers are discovered via HELLO or heartbeat
+- **Sync dot now updates on roster change** — the online indicator cross-checks `addonUsers` against the guild roster cache; it now re-evaluates whenever the roster rebuilds
+- **Bottom bar buttons no longer overlap the resize grip** — the bar's right edge is offset far enough from the corner that it no longer touches the resize dragger
+- **Fixed instances causing false DR eviction** — GUILD addon messages are not delivered inside instances and arenas. The DR heartbeat watchdog now pauses eviction while the player is in an instance, preventing a false re-election every 3 minutes when the DR zones in
 
-    - **Expansion filter buttons** — two toggle buttons `[Vanilla]` and `[TBC]` in the search bar let you narrow the recipe display to Original Classic recipes, TBC recipes, or both. Filter state persists across reloads per character. Both are active by default so first-run behaviour is unchanged
-    - **Accurate TBC classification** — recipes are classified via a pre-generated lookup table (`TBC_ITEM_IDS`) covering all TBC crafting professions. Lookup is a direct hash — no per-frame scan, zero runtime cost
-    - **Enchanting fully covered** — enchanting recipe keys are `-spellID` as returned by `GetCraftRecipeLink`; the lookup table is keyed accordingly so all TBC enchants classify correctly
+### Removed
 
-    ---
+- **Craft request protocol** — the peer-to-peer craft request / accept / decline / complete flow (popup, comms commands, queue) has been removed. The `[W]` whisper button is the replacement workflow
 
-    ## 1.2.1 — Data Clarity & Search UX — 2026-03-13
+---
 
-    ### New Features
+## 1.2.2 — Expansion Filter — 2026-03-13
 
-    - **Online-only crafter filter** — a new `[Online]` toggle button in the profession header bar filters the crafter display in Recipes view and Search Results to show only online crafters. Toggle state persists across reloads. When active, recipes with no online crafter show `—`
-    - **"Scanned: N ago" timestamp in member detail** — the member recipe panel now shows a small grey label (`Scanned: 2h ago`, `Scanned: 3d ago`, etc.) below the member name so you can immediately judge how fresh the data is
-    - **Specialisation description tooltip** — hovering a member row that shows a specialisation tag (e.g. `[Transmutation Master]`, `[Dragonscale Leatherworking]`) now pops a GameTooltip with a plain-English explanation of what the spec unlocks
-    - **Better empty search state** — searching for a term with no results now shows a clear "Nobody in the guild knows X" message instead of a silent blank
+### New Features
 
-    ---
+- **Expansion filter buttons** — two toggle buttons `[Vanilla]` and `[TBC]` in the search bar let you narrow the recipe display to Original Classic recipes, TBC recipes, or both. Filter state persists across reloads per character. Both are active by default so first-run behaviour is unchanged
+- **Accurate TBC classification** — recipes are classified via a pre-generated lookup table (`TBC_ITEM_IDS`) covering all TBC crafting professions. Lookup is a direct hash — no per-frame scan, zero runtime cost
+- **Enchanting fully covered** — enchanting recipe keys are `-spellID` as returned by `GetCraftRecipeLink`; the lookup table is keyed accordingly so all TBC enchants classify correctly
 
-    ## 1.2.0 — Protocol Correctness — 2026-03-12
+---
 
-    ### New Features
+## 1.2.1 — Data Clarity & Search UX — 2026-03-13
 
-    - **Cooking now tracked** — raid food, utility food, and all Cooking recipes are now included in the guild database, search, and tooltip injection (closes #60)
+### New Features
 
-    ### Improvements
+- **Online-only crafter filter** — a new `[Online]` toggle button in the profession header bar filters the crafter display in Recipes view and Search Results to show only online crafters. Toggle state persists across reloads. When active, recipes with no online crafter show `—`
+- **"Scanned: N ago" timestamp in member detail** — the member recipe panel now shows a small grey label (`Scanned: 2h ago`, `Scanned: 3d ago`, etc.) below the member name so you can immediately judge how fresh the data is
+- **Specialisation description tooltip** — hovering a member row that shows a specialisation tag (e.g. `[Transmutation Master]`, `[Dragonscale Leatherworking]`) now pops a GameTooltip with a plain-English explanation of what the spec unlocks
+- **Better empty search state** — searching for a term with no results now shows a clear "Nobody in the guild knows X" message instead of a silent blank
 
-    - **Term-based DR authority** — the Designated Router now carries a monotone term counter in every message. If a DR is replaced by a new election, any late-arriving messages from the old DR are silently discarded, preventing stale data from overwriting newer guild recipes
-    - **Immediate step-down** — if a node is currently acting as DR and receives a heartbeat from a higher-term authority, it steps down instantly and triggers a fresh election rather than waiting for the next heartbeat cycle
+---
 
-    ### Fixes
+## 1.2.0 — Protocol Correctness — 2026-03-12
 
-    - Fixed a race where the old DR kept responding to sync requests after being superseded, because `myRole` was not updated until the next heartbeat timeout
+### New Features
 
-    ---
+- **Cooking now tracked** — raid food, utility food, and all Cooking recipes are now included in the guild database, search, and tooltip injection (closes #60)
 
-    ## 1.1.8a — 2026-03-10
+### Improvements
 
-    ### New Features
+- **Term-based DR authority** — the Designated Router now carries a monotone term counter in every message. If a DR is replaced by a new election, any late-arriving messages from the old DR are silently discarded, preventing stale data from overwriting newer guild recipes
+- **Immediate step-down** — if a node is currently acting as DR and receives a heartbeat from a higher-term authority, it steps down instantly and triggers a fresh election rather than waiting for the next heartbeat cycle
 
-    - **Hover crafter names to see the full list** — hovering the crafter text (right side of a recipe row) in Search results and Recipes view shows a tooltip with all crafters and their online status
-    - **Hover a reagent to see its tooltip** — expanding a recipe and hovering any reagent line shows the native WoW item tooltip
+### Fixes
 
-    ### Fixes
+- Fixed a race where the old DR kept responding to sync requests after being superseded, because `myRole` was not updated until the next heartbeat timeout
 
-    - Tooltip hit zone is now scoped to the recipe name only — hovering the crafter list, expand icon, or post button no longer triggers the item tooltip
-    - Fixed potential tooltip flicker when moving the cursor between the recipe name and the rest of the row
+---
 
-    ---
+## 1.1.8a — 2026-03-10
 
-    ## 1.1.8 — Recipe Hover Tooltips — 2026-03-10
+### New Features
 
-    ### New Features
+- **Hover crafter names to see the full list** — hovering the crafter text (right side of a recipe row) in Search results and Recipes view shows a tooltip with all crafters and their online status
+- **Hover a reagent to see its tooltip** — expanding a recipe and hovering any reagent line shows the native WoW item tooltip
 
-    - **Hover a recipe name to see its tooltip** — hovering the recipe name in Search results, Recipes view, member detail, or Favorites shows the native WoW item or spell tooltip. Enchanting recipes (spell-based) show the spell tooltip; all other professions show the item tooltip
+### Fixes
 
-    ---
+- Tooltip hit zone is now scoped to the recipe name only — hovering the crafter list, expand icon, or post button no longer triggers the item tooltip
+- Fixed potential tooltip flicker when moving the cursor between the recipe name and the rest of the row
 
-    ## 1.1.7a — Guild Chat Fixes — 2026-03-08
+---
 
-    ### Fixes
+## 1.1.8 — Recipe Hover Tooltips — 2026-03-10
 
-    - Fixed responses occasionally posting twice in quick succession
-    - Fixed guild chat messages being cut off mid-name
-    - Fixed typo searches matching too many unrelated recipes
-    - Fixed multiple addon users all responding at the same time when the primary responder was offline
-    - Crafter list in `!gc` replies is now limited to 2 names + "+X more" to keep messages short
+### New Features
 
-    ---
+- **Hover a recipe name to see its tooltip** — hovering the recipe name in Search results, Recipes view, member detail, or Favorites shows the native WoW item or spell tooltip. Enchanting recipes (spell-based) show the spell tooltip; all other professions show the item tooltip
 
-    ## 1.1.7 — Guild Chat Integration — 2026-03-08
+---
 
-    ### New Features
+## 1.1.7a — Guild Chat Fixes — 2026-03-08
 
-    - **`!gc <recipe>` in guild chat** — type `!gc shadowcloth` and the addon posts matching crafters right in guild chat. No addon needed to ask, anyone can use it
-    - **Post crafters button** — every recipe row now has a small `[>]` button to share that recipe's crafters to guild chat with one click
+### Fixes
 
-    ### Improvements
+- Fixed responses occasionally posting twice in quick succession
+- Fixed guild chat messages being cut off mid-name
+- Fixed typo searches matching too many unrelated recipes
+- Fixed multiple addon users all responding at the same time when the primary responder was offline
+- Crafter list in `!gc` replies is now limited to 2 names + "+X more" to keep messages short
 
-    - Fuzzy search so typos still find the right recipe (e.g. "shadwcloth" → Shadowcloth)
-    - Shift-clicking an item into `!gc` works correctly
-    - 30-second cooldown per recipe/query to prevent accidental spam
+---
 
-    ---
+## 1.1.7 — Guild Chat Integration — 2026-03-08
 
-    ## 1.1.6 — Multi-Language Support — 2026-03-07
+### New Features
 
-    ### New Features
+- **`!gc <recipe>` in guild chat** — type `!gc shadowcloth` and the addon posts matching crafters right in guild chat. No addon needed to ask, anyone can use it
+- **Post crafters button** — every recipe row now has a small `[>]` button to share that recipe's crafters to guild chat with one click
 
-    - **Mixed-language guilds now work** — French, German, English and other client languages all see recipes in their own language, regardless of what language the crafter scanned them in
-    - Recipe search, tooltips, and favorites all show correctly localised names
+### Improvements
 
-    ---
+- Fuzzy search so typos still find the right recipe (e.g. "shadwcloth" → Shadowcloth)
+- Shift-clicking an item into `!gc` works correctly
+- 30-second cooldown per recipe/query to prevent accidental spam
 
-    ## 1.1.5b — Stability Fixes — 2026-03-03
+---
 
-    ### Fixes
+## 1.1.6 — Multi-Language Support — 2026-03-07
 
-    - Fixed guild members appearing twice in the member list
-    - Fixed recipes being lost when two entries for the same character existed
-    - Fixed the addon user count showing too low on login or too high over time
-    - Reduced chat noise when many addon users log in at the same time
+### New Features
 
-    ---
+- **Mixed-language guilds now work** — French, German, English and other client languages all see recipes in their own language, regardless of what language the crafter scanned them in
+- Recipe search, tooltips, and favorites all show correctly localised names
 
-    ## 1.1.5a — 2026-03-03
+---
 
-    ### Fixes
+## 1.1.5b — Stability Fixes — 2026-03-03
 
-    - Fixed hunter pet abilities (Claw, Dash, Dive, etc.) showing up as Enchanting recipes for hunters
+### Fixes
 
-    ---
+- Fixed guild members appearing twice in the member list
+- Fixed recipes being lost when two entries for the same character existed
+- Fixed the addon user count showing too low on login or too high over time
+- Reduced chat noise when many addon users log in at the same time
 
-    ## 1.1.5 — UI Overhaul — 2026-03-01
+---
 
-    ### New Features
+## 1.1.5a — 2026-03-03
 
-    - **Recipe quality colors** — recipe names are colored by rarity (grey/white/green/blue/purple/orange) so rare recipes stand out
-    - **Collapsible reagent rows** — click any recipe to expand its material list; collapsed by default for a clean view
-    - **"Recipes" view** — new toggle to switch between a per-member recipe list and an aggregated "who can craft this?" view per profession
-    - **Polished sidebar** — dark rows with a gold accent bar on the selected profession and a blue hover highlight
+### Fixes
 
-    ### Fixes
+- Fixed hunter pet abilities (Claw, Dash, Dive, etc.) showing up as Enchanting recipes for hunters
 
-    - Fixed the "Select a profession" message overlapping recipe content in various situations
-    - Fixed crafters showing twice in search results
-    - Fixed recipes always showing `~` (missing reagents) in the Recipe view
-    - Fixed quality colors not loading until the window was reopened
-    - Fixed expand/collapse icons showing as rectangles on some clients
+---
 
-    ---
+## 1.1.5 — UI Overhaul — 2026-03-01
 
-    ## 1.1.0 — Favorites — 2026-02-27
+### New Features
 
-    ### New Features
+- **Recipe quality colors** — recipe names are colored by rarity (grey/white/green/blue/purple/orange) so rare recipes stand out
+- **Collapsible reagent rows** — click any recipe to expand its material list; collapsed by default for a clean view
+- **"Recipes" view** — new toggle to switch between a per-member recipe list and an aggregated "who can craft this?" view per profession
+- **Polished sidebar** — dark rows with a gold accent bar on the selected profession and a blue hover highlight
 
-    - **Favorites** — star recipes and crafters for quick access. New Favorites tab with Members and Recipes sub-tabs
+### Fixes
 
-    ### Improvements
+- Fixed the "Select a profession" message overlapping recipe content in various situations
+- Fixed crafters showing twice in search results
+- Fixed recipes always showing `~` (missing reagents) in the Recipe view
+- Fixed quality colors not loading until the window was reopened
+- Fixed expand/collapse icons showing as rectangles on some clients
 
-    - Members who leave the guild are automatically removed after 30 days
-    - Reduced SavedVariables size by deduplicating shared recipe data
+---
 
-    ### Fixes
+## 1.1.0 — Favorites — 2026-02-27
 
-    - Fixed star icons showing as rectangles
-    - Fixed empty state messages overlapping in the Favorites tab
+### New Features
 
-    ---
+- **Favorites** — star recipes and crafters for quick access. New Favorites tab with Members and Recipes sub-tabs
 
-    ## 1.0.4 — 2026-02-26
+### Improvements
 
-    ### Fixes
+- Members who leave the guild are automatically removed after 30 days
+- Reduced SavedVariables size by deduplicating shared recipe data
 
-    - Fixed characters in multiple guilds on the same account sharing (and corrupting) each other's data
+### Fixes
 
-    ---
+- Fixed star icons showing as rectangles
+- Fixed empty state messages overlapping in the Favorites tab
 
-    ## 1.0.3 — 2026-02-25
+---
 
-    ### Fixes
+## 1.0.4 — 2026-02-26
 
-    - Fixed missing reagents on some recipes when the game hadn't fully loaded the item data yet (e.g. Enchant Gloves - Spell Strike)
+### Fixes
 
-    ---
+- Fixed characters in multiple guilds on the same account sharing (and corrupting) each other's data
 
-    ## 1.0.2 — 2026-02-23
+---
 
-    ### Fixes
+## 1.0.3 — 2026-02-25
 
-    - Removed noisy role-change messages from chat (debug only now)
-    - Fixed `/gc minimap` toggle not working
+### Fixes
 
-    ---
+- Fixed missing reagents on some recipes when the game hadn't fully loaded the item data yet (e.g. Enchant Gloves - Spell Strike)
 
-    ## 1.0.1 — 2026-02-23
+---
 
-    ### Fixes
+## 1.0.2 — 2026-02-23
 
-    - Fixed new members showing as "683 months old"
-    - Fixed peers not discovering each other correctly on login
-    - Fixed scroll panels cutting off the last entry
-    - Fixed minimap button position on square minimap addons (Titan Panel, SexyMap)
-    - Fixed reagents missing from synced recipe data
-    - Fixed craft request popups appearing during combat
-    - Fixed sync getting stuck when already up to date
-    - Various search and navigation display fixes
+### Fixes
 
-    ---
+- Removed noisy role-change messages from chat (debug only now)
+- Fixed `/gc minimap` toggle not working
 
-    ## 1.0.0 — 2026-02-22
+---
 
-    - Initial release
+## 1.0.1 — 2026-02-23
+
+### Fixes
+
+- Fixed new members showing as "683 months old"
+- Fixed peers not discovering each other correctly on login
+- Fixed scroll panels cutting off the last entry
+- Fixed minimap button position on square minimap addons (Titan Panel, SexyMap)
+- Fixed reagents missing from synced recipe data
+- Fixed craft request popups appearing during combat
+- Fixed sync getting stuck when already up to date
+- Various search and navigation display fixes
+
+---
+
+## 1.0.0 — 2026-02-22
+
+- Initial release

--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -89,6 +89,9 @@ function Comms:OnInitialize()
     -- Pending re-sync debounce timer (shared across HandleHello / TouchAddonUser / RecomputeElection)
     self._pendingSyncTimer = nil
 
+    -- BroadcastHello pause-reschedule timer (tracked so we never accumulate duplicates)
+    self._helloRescheduleTimer = nil
+
     -- Registered flag
     self._prefixRegistered = false
 end
@@ -128,6 +131,17 @@ end
 ----------------------------------------------------------------------
 
 function Comms:BroadcastHello()
+    if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then
+        GuildCrafts:Debug("BroadcastHello delayed (SyncPausePolicy) — rescheduling in 5s")
+        -- Cancel any existing reschedule timer before creating a new one so that
+        -- a long pause doesn't accumulate N timers that all fire on unpause.
+        if self._helloRescheduleTimer then
+            self:CancelTimer(self._helloRescheduleTimer)
+        end
+        self._helloRescheduleTimer = self:ScheduleTimer("BroadcastHello", 5)
+        return
+    end
+    self._helloRescheduleTimer = nil
     local playerKey = GuildCrafts.Data:GetPlayerKey()
     self:SendMessage(MSG_HELLO, {
         sender  = playerKey,
@@ -427,6 +441,13 @@ end
 
 function Comms:SendSyncRequest()
     if not IsInGuild() then return end
+    if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then
+        GuildCrafts:Debug("SendSyncRequest delayed (SyncPausePolicy) — rescheduling in 10s")
+        if self.syncTimer then self:CancelTimer(self.syncTimer) end
+        self.syncTimer = self:ScheduleTimer("SendSyncRequest", 10)
+        self.syncPending = true  -- prevent duplicate sync chains while deferred
+        return
+    end
 
     local playerKey = GuildCrafts.Data:GetPlayerKey()
 
@@ -769,6 +790,10 @@ end
 ----------------------------------------------------------------------
 
 function Comms:BroadcastNewRecipes(memberKey, profName, recipes)
+    if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then
+        GuildCrafts:Debug("BroadcastNewRecipes suppressed (SyncPausePolicy) for", profName)
+        return
+    end
     local gdb = GuildCrafts.Data:GetGuildDB()
     local entry = gdb and gdb[memberKey]
     self:SendMessage(MSG_DELTA_UPDATE, {
@@ -782,6 +807,10 @@ function Comms:BroadcastNewRecipes(memberKey, profName, recipes)
 end
 
 function Comms:BroadcastProfessionRemoval(memberKey, profName)
+    if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then
+        GuildCrafts:Debug("BroadcastProfessionRemoval suppressed (SyncPausePolicy) for", profName)
+        return
+    end
     local gdb = GuildCrafts.Data:GetGuildDB()
     local entry = gdb and gdb[memberKey]
     self:SendMessage(MSG_DELTA_UPDATE, {
@@ -798,6 +827,10 @@ end
 --- prevents peers (including the DR) from pruning a player who is simply up to
 --- date and has nothing new to learn.
 function Comms:BroadcastTimestampTouch(memberKey, profName)
+    if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then
+        GuildCrafts:Debug("BroadcastTimestampTouch suppressed (SyncPausePolicy) for", profName)
+        return
+    end
     -- Rate limit: only broadcast once per hour per profession to avoid spamming
     -- the DR when the player opens a profession window repeatedly.
     self._lastTouchBroadcast = self._lastTouchBroadcast or {}
@@ -883,6 +916,14 @@ end
 --- Each chunk is sent after a SYNC_CHUNK_DELAY to avoid burst lag.
 --- onComplete is an optional callback fired after the last chunk is sent.
 function Comms:SendChunked(msgType, memberData, target, totalCount, onComplete)
+    if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then
+        GuildCrafts:Debug("SendChunked suppressed (SyncPausePolicy):", msgType)
+        -- We must still call onComplete so syncProcessing is cleared and the
+        -- DR's queue doesn't deadlock permanently. Affected requesters will not
+        -- receive their SYNC_RESPONSE and will retry via SYNC_TIMEOUT (120 s).
+        if onComplete then onComplete() end
+        return
+    end
     local keys = {}
     for k in pairs(memberData) do
         keys[#keys + 1] = k
@@ -924,6 +965,10 @@ end
 
 --- Serialize, optionally compress, and send a message.
 function Comms:SendMessage(msgType, payload, distribution, target, priority)
+    if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then
+        GuildCrafts:Debug("SendMessage suppressed (SyncPausePolicy):", msgType)
+        return
+    end
     local envelope = {
         t    = msgType,           -- type
         v    = GuildCrafts.VERSION,

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.3.8"
+GuildCrafts.DISPLAY_VERSION = "1.4.0"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -7,7 +7,7 @@ local _, _ns = ... -- luacheck: ignore (WoW addon bootstrap)
 local GuildCrafts = _G.GuildCrafts
 
 -- Create the Data module
-local Data = GuildCrafts:NewModule("Data")
+local Data = GuildCrafts:NewModule("Data", "AceTimer-3.0")
 GuildCrafts.Data = Data
 
 -- Local references for performance
@@ -931,6 +931,22 @@ function Data:ScanTradeSkill()
     numSkills = GetNumTradeSkills()
 
     local recipes = entry.professions[profName].recipes
+
+    -- Partial-scan protection (pre-loop): if the window returned fewer total entries
+    -- than half of what we have stored, the frame hasn't finished loading. Skip the
+    -- scan and reschedule so we don't write partial data. Must run before the loop
+    -- so nothing is written to `recipes` before we can bail.
+    do
+        local existingCount = 0
+        for _ in pairs(recipes) do existingCount = existingCount + 1 end
+        if existingCount > 0 and numSkills > 0 and numSkills < (existingCount * 0.5) then
+            GuildCrafts:Debug("ScanTradeSkill: partial-scan guard triggered for", profName,
+                "(numSkills", numSkills, "< 50% of existing", existingCount, ") — deferring 2s")
+            self:ScheduleTimer("ScanTradeSkill", 2)
+            return
+        end
+    end
+
     local newCount = 0
     local newRecipes = {}
     local currentCategory = nil
@@ -1116,6 +1132,19 @@ function Data:ScanCraft()
     end
 
     local recipes = entry.professions[profName].recipes
+
+    -- Partial-scan protection (pre-loop): same logic as ScanTradeSkill.
+    do
+        local existingCount = 0
+        for _ in pairs(recipes) do existingCount = existingCount + 1 end
+        if existingCount > 0 and numCrafts > 0 and numCrafts < (existingCount * 0.5) then
+            GuildCrafts:Debug("ScanCraft: partial-scan guard triggered for", profName,
+                "(numCrafts", numCrafts, "< 50% of existing", existingCount, ") — deferring 2s")
+            self:ScheduleTimer("ScanCraft", 2)
+            return
+        end
+    end
+
     local newCount = 0
     local newRecipes = {}
     local currentCategory = nil
@@ -1328,10 +1357,35 @@ function Data:MergeIncoming(incomingData)
                     or (incomingEntry.lastUpdate == localEntry.lastUpdate
                         and (incomingEntry.dataFormat or 0) > (localEntry.dataFormat or 0))
                 if dominated then
-                    gdb[memberKey] = incomingEntry
-                    self:ExtractToRecipeDB(incomingEntry)
-                    changed = true
-                    GuildCrafts:Debug("Merged data for:", memberKey)
+                    -- Partial-scan protection: if the incoming entry has a profession
+                    -- with suspiciously few recipes compared to what we already store
+                    -- for that member, skip the merge to avoid overwriting good data.
+                    local suspicious = false
+                    if localEntry then
+                        for profName, incomingProf in pairs(incomingEntry.professions or {}) do
+                            local incomingCount = 0
+                            for _ in pairs(incomingProf.recipes or {}) do incomingCount = incomingCount + 1 end
+                            local localProf = localEntry.professions and localEntry.professions[profName]
+                            local existingCount = 0
+                            if localProf then
+                                for _ in pairs(localProf.recipes or {}) do existingCount = existingCount + 1 end
+                            end
+                            if incomingCount > 0 and existingCount > 0
+                                    and incomingCount < (existingCount * 0.5) then
+                                GuildCrafts:Debug("MergeIncoming: partial-scan guard blocked",
+                                    memberKey, profName,
+                                    "(incoming", incomingCount, "< 50% of existing", existingCount, ")")
+                                suspicious = true
+                                break
+                            end
+                        end
+                    end
+                    if not suspicious then
+                        gdb[memberKey] = incomingEntry
+                        self:ExtractToRecipeDB(incomingEntry)
+                        changed = true
+                        GuildCrafts:Debug("Merged data for:", memberKey)
+                    end
                 end
             end
         end

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.3.8
+## Version: 1.4.0
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild
@@ -14,6 +14,7 @@ Libs\embeds.xml
 Core.lua
 Data.lua
 Data_TBC.lua
+SyncPausePolicy.lua
 Comms.lua
 Favorites.lua
 Tooltip.lua

--- a/GuildCrafts/SyncPausePolicy.lua
+++ b/GuildCrafts/SyncPausePolicy.lua
@@ -1,0 +1,126 @@
+----------------------------------------------------------------------
+-- GuildCrafts — SyncPausePolicy.lua
+-- Suspends all outgoing sync traffic during high-activity game states
+-- where addon channel messages are likely to be dropped or throttled.
+--
+-- Pause conditions:
+--   • In combat (InCombatLockdown) — cleared 6s after PLAYER_REGEN_ENABLED
+--   • Inside an instance (IsInInstance) — cleared 15s after zone-in
+--   • Zone transition in progress — cleared 12s after PLAYER_ENTERING_WORLD
+--
+-- Public API:
+--   GuildCrafts.SyncPausePolicy:ShouldPause() → boolean
+----------------------------------------------------------------------
+local _, _ns = ... -- luacheck: ignore (WoW addon bootstrap)
+local GuildCrafts = _G.GuildCrafts
+
+local SyncPausePolicy = GuildCrafts:NewModule("SyncPausePolicy", "AceEvent-3.0", "AceTimer-3.0")
+GuildCrafts.SyncPausePolicy = SyncPausePolicy
+
+-- Grace period durations (seconds)
+local GRACE_COMBAT     =  6   -- after PLAYER_REGEN_ENABLED
+local GRACE_INSTANCE   = 15   -- after entering/leaving an instance
+local GRACE_TRANSITION = 12   -- after any non-login PLAYER_ENTERING_WORLD
+
+----------------------------------------------------------------------
+-- State
+----------------------------------------------------------------------
+
+function SyncPausePolicy:OnInitialize()
+    -- Each flag is set to true while the corresponding condition is active
+    -- (including its grace period).  ShouldPause returns true if any is set.
+    self._inCombat     = false
+    self._inInstance   = false
+    self._inTransition = false
+
+    -- Active grace timers (cancelled if condition re-triggers before expiry)
+    self._combatTimer     = nil
+    self._instanceTimer   = nil
+    self._transitionTimer = nil
+end
+
+function SyncPausePolicy:OnEnable()
+    self:RegisterEvent("PLAYER_REGEN_ENABLED",  "OnCombatEnd")
+    self:RegisterEvent("PLAYER_REGEN_DISABLED", "OnCombatStart")
+    self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnZoneEnter")
+
+    -- Capture the initial state at login (combat is theoretically possible
+    -- on PvP servers via world PvP, though unlikely on login).
+    if InCombatLockdown() then
+        self._inCombat = true
+    end
+    local inInstance = IsInInstance and select(1, IsInInstance())
+    if inInstance then
+        self._inInstance = true
+    end
+end
+
+----------------------------------------------------------------------
+-- Event Handlers
+----------------------------------------------------------------------
+
+function SyncPausePolicy:OnCombatStart()
+    -- Cancel any pending grace-off timer so we don't clear the flag too early
+    if self._combatTimer then
+        self:CancelTimer(self._combatTimer)
+        self._combatTimer = nil
+    end
+    self._inCombat = true
+    GuildCrafts:Debug("SyncPausePolicy: combat started — sync paused")
+end
+
+function SyncPausePolicy:OnCombatEnd()
+    if self._combatTimer then
+        self:CancelTimer(self._combatTimer)
+    end
+    self._combatTimer = self:ScheduleTimer(function()
+        self._inCombat    = false
+        self._combatTimer = nil
+        GuildCrafts:Debug("SyncPausePolicy: combat grace expired — sync resumed")
+    end, GRACE_COMBAT)
+    GuildCrafts:Debug("SyncPausePolicy: combat ended — grace timer started")
+end
+
+function SyncPausePolicy:OnZoneEnter(_, isLogin)
+    -- Zone transition: always apply the short grace period
+    if self._transitionTimer then
+        self:CancelTimer(self._transitionTimer)
+    end
+    if not isLogin then
+        self._inTransition = true
+        self._transitionTimer = self:ScheduleTimer(function()
+            self._inTransition   = false
+            self._transitionTimer = nil
+            GuildCrafts:Debug("SyncPausePolicy: zone-transition grace expired — sync resumed")
+        end, GRACE_TRANSITION)
+        GuildCrafts:Debug("SyncPausePolicy: zone transition detected — sync paused")
+    end
+
+    -- Instance check: apply the longer grace period when entering or leaving
+    local inInstance = IsInInstance and select(1, IsInInstance())
+    if self._instanceTimer then
+        self:CancelTimer(self._instanceTimer)
+    end
+    if inInstance then
+        self._inInstance = true
+        -- No grace timer while still inside — stays paused until next zone-in
+        GuildCrafts:Debug("SyncPausePolicy: inside instance — sync paused")
+    else
+        -- Just left an instance (or logged in outside one).
+        -- Apply grace period before allowing sync traffic.
+        self._instanceTimer = self:ScheduleTimer(function()
+            self._inInstance   = false
+            self._instanceTimer = nil
+            GuildCrafts:Debug("SyncPausePolicy: instance grace expired — sync resumed")
+        end, GRACE_INSTANCE)
+    end
+end
+
+----------------------------------------------------------------------
+-- Public API
+----------------------------------------------------------------------
+
+--- Returns true if outgoing sync messages should be suppressed right now.
+function SyncPausePolicy:ShouldPause()
+    return self._inCombat or self._inInstance or self._inTransition
+end

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The addon itself. This is the folder you drop into `World of Warcraft/_classic_/
 | `Core.lua` | Entry point — addon initialisation, event routing, slash commands |
 | `Data.lua` | Recipe scanning, profession detection, expansion classification, data storage, merge logic |
 | `Data_TBC.lua` | Pre-generated TBC recipe lookup table (`TBC_ITEM_IDS`) used by the expansion filter |
+| `SyncPausePolicy.lua` | Pause gate — suppresses outgoing sync during combat, instances, and zone transitions |
 | `Comms.lua` | Network layer — DR/BDR election, sync protocol, delta updates, craft messages |
 | `Tooltip.lua` | Item tooltip hook — shows guild crafters on hover |
 | `MinimapButton.lua` | Draggable minimap icon toggle |

--- a/spec/implementation-plan-v2.md
+++ b/spec/implementation-plan-v2.md
@@ -1,0 +1,299 @@
+# GuildCrafts — Implementation Plan v2
+
+> Planned improvements following the v1 release. Each item is self-contained and can be implemented independently. Ordered by estimated value-to-effort ratio.
+
+---
+
+## 1 — SyncPausePolicy
+
+**Priority: High | Effort: Low**
+
+Suspend all outgoing sync traffic during high-activity game states where chat messages are most likely to be dropped, throttled, or disruptive.
+
+### Pause conditions
+| Condition | How to detect | Grace after |
+|---|---|---|
+| Player is in combat | `InCombatLockdown()` returns true | 6s after `PLAYER_REGEN_ENABLED` |
+| Player is inside an instance | `IsInInstance()` returns true | 15s after `PLAYER_LEAVING_WORLD` → `PLAYER_ENTERING_WORLD` |
+| Zone transition in progress | `PLAYER_ENTERING_WORLD` fires with `isLogin == false` | 12s |
+
+### Implementation
+- New module: `SyncPausePolicy.lua`
+- Tracks the current pause state and the reason for it
+- Exposes a single method: `SyncPausePolicy:ShouldPause()` → boolean
+- Every outgoing send site in `Comms.lua` checks this before firing:
+  ```lua
+  if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then return end
+  ```
+- Comms registers `PLAYER_REGEN_ENABLED`, `PLAYER_ENTERING_WORLD` events to clear the pause state after grace timers expire
+- Grace timers use `AceTimer:ScheduleTimer` to avoid firing while still transitioning
+
+### File changes
+- New file: `SyncPausePolicy.lua` (~60 lines)
+- `Comms.lua`: add pause check at the top of `SendMessage`, `SendChunked`, `BroadcastHello`, `SendSyncRequest`, `BroadcastNewRecipes`, `BroadcastTimestampTouch`, `BroadcastProfessionRemoval`
+- `GuildCrafts.toc`: add `SyncPausePolicy.lua` before `Comms.lua`
+- `Core.lua`: instantiate module after AceAddon init
+
+---
+
+## 2 — Partial Scan Protection
+
+**Priority: High | Effort: Low**
+
+Prevent a partial or early-terminated profession scan from silently overwriting a complete existing entry. The WoW API sometimes returns 0 or very few recipes if the profession window hasn't finished loading, or if the client is under load. Merging this destroys good data.
+
+### Detection heuristic
+When `MergeIncoming` (or `ScanTradeSkill`/`ScanCraft`) is about to write a profession entry, compare the incoming recipe count against the stored count:
+
+```
+if incomingCount > 0 and existingCount > 0
+   and incomingCount < (existingCount * 0.5)
+then
+    → skip merge, emit debug warning
+end
+```
+
+The 50% threshold avoids false positives when a player genuinely unlearns half their recipes (which is very rare), while catching the common case of a 2-recipe scan replacing a 300-recipe entry.
+
+### Self-scan vs incoming sync
+
+The guard applies to both paths:
+- **Local scan** (`ScanTradeSkill`, `ScanCraft`): if `GetNumTradeSkills()` returns a suspiciously low count compared to the stored count, skip the write and schedule a rescan after a 2s delay (when the window is more likely to be fully loaded)
+- **Incoming sync** (`MergeIncoming`): check per-profession before merging. If suspicious, keep the existing entry and log which sender triggered the skip
+
+### File changes
+- `Data.lua`: add guard inside `MergeIncoming` and inside `ScanTradeSkill`/`ScanCraft` before writing
+- No new files required
+
+---
+
+## 3 — Immediate Advertise Broadcast (AD message)
+
+**Priority: High | Effort: Low–Medium**
+
+Currently a new recipe scan only propagates to peers on the next full sync cycle (triggered by DR election or another HELLO). This means peers can be up to `SYNC_DELAY` + election time behind.
+
+### New message type: `DELTA_AD`
+
+When the local player scans a profession and the data changed, immediately broadcast a lightweight advertisement:
+
+```lua
+{
+    type      = "DELTA_AD",
+    sender    = playerKey,
+    memberKey = playerKey,
+    rev       = newTimestamp,
+    profCounts = { ["Alchemy"] = 312, ["Engineering"] = 187 }
+}
+```
+
+This message is tiny — no recipe data, just a timestamp and counts per profession.
+
+### Receiver behaviour
+
+Any peer who receives a `DELTA_AD` and sees that the advertised `rev` is newer than what they have stored for `memberKey` should:
+1. Note the timestamp for display purposes immediately (the sender is clearly active and up to date)
+2. If they are the DR: broadcast `DELTA_AD` to the guild so all non-DR nodes also get the hint
+3. Queue a whisper-based `SYNC_REQUEST` for just that member after a short jitter (1–5s) to avoid a thundering-herd pull when the whole guild is online
+
+### Distinction from existing `DELTA_UPDATE`
+
+`DELTA_UPDATE` carries actual recipe data — it is the response. `DELTA_AD` is just the announcement that new data exists. Peers who already have a matching or newer timestamp ignore it. This keeps broadcast traffic minimal.
+
+### File changes
+- `Comms.lua`: add `MSG_DELTA_AD = "DELTA_AD"`, add `BroadcastLocalAdvertise()` called from `Core.lua` after a scan detects changes, add `HandleDeltaAd()` in the receive dispatcher
+- `Core.lua`: call `Comms:BroadcastLocalAdvertise()` from `OnTradeSkillShow` and `OnCraftShow` when `changed == true`
+
+---
+
+## 4 — Chunk RESUME / Recovery
+
+**Priority: Medium | Effort: Medium**
+
+Currently if a chunk is dropped mid-transfer, the requester waits until `SYNC_TIMEOUT` (120s) before retrying the full transfer. Adding sequence-number acknowledgment allows partial recovery in ~4s.
+
+### How it works
+
+**Sender side:**
+- Already assigns `chunkIndex` / `chunkTotal` to each chunk
+- Add a `sessionId` field (unique per transfer, e.g. `memberKey:timestamp:randomSuffix`)
+- Keep chunks in a short-lived outgoing session table keyed by `sessionId`, TTL ~35s
+
+**Receiver side:**
+- Track received chunk indices in a `partialReceive[memberKey]` table: `{ sessionId, seen = {[1]=true, [3]=true, ...}, total = N, lastProgressAt = time() }`
+- After receiving any chunk, check if all `1..total` are present. If yes, finalize the merge and delete state
+- Start a `PROGRESS_TIMEOUT` timer (4s) reset on each received chunk. If it fires and chunks are missing, send a `RESUME` message via whisper listing the missing seq numbers
+
+**New message type: `SYNC_RESUME`:**
+```lua
+{
+    type      = "SYNC_RESUME",
+    sessionId = sessionId,
+    memberKey = memberKey,
+    missing   = { 2, 5, 7 }   -- seq numbers not yet received
+}
+```
+
+**Sender on `SYNC_RESUME`:** resend only the listed chunks from the session table. If the session has already expired, send nothing — the normal timeout/retry path will handle it.
+
+### Max resume attempts
+Cap at 3 resume attempts per transfer. If chunks are still missing after that, fail the request normally and requeue.
+
+### File changes
+- `Comms.lua`: add `MSG_SYNC_RESUME`, `sessionId` generation, outgoing session table, `SendChunked` stores chunks, `HandleSyncResume`, `partialReceive` tracking in `HandleSyncResponse`, progress timeout via `AceTimer`
+- `Data.lua`: no changes (merge path is unchanged)
+
+---
+
+## 5 — Per-Peer Backoff
+
+**Priority: Medium | Effort: Medium**
+
+Currently a sync timeout evicts the entire DR/BDR and forces a re-election. This is heavy-handed — the DR may be briefly unresponsive due to loading, instance transition, or chat throttle, not because it has crashed.
+
+### Failure tracking
+
+Maintain a per-peer failure table in `Comms`:
+```lua
+self.peerFailures = {
+    ["Name-Realm"] = { count = N, lastFailedAt = timestamp }
+}
+```
+
+- Increment `count` on: sync timeout, empty SYNC_RESPONSE when non-empty was expected, no SYNC_RESPONSE at all
+- Reset `count` on: successful SYNC_RESPONSE from that peer, successful SYNC_PUSH from that peer
+- Record `lastFailedAt` on every failure
+
+### Backoff logic
+
+Before dispatching a sync request to a peer, check:
+```lua
+if peer.count >= 2 and (time() - peer.lastFailedAt) < 45 then
+    -- skip this peer this cycle, try BDR or other known nodes
+end
+```
+
+This means a briefly broken DR is bypassed for 45s. During that window:
+- If the local client is the next-best node (BDR), it promotes itself for the request
+- If neither DR nor BDR are usable, find the next alphabetically sorted addon user who is not in backoff
+
+### Distinguish from DR eviction
+
+Full DR eviction (removing from `addonUsers`) is kept as a last resort after backoff exhaustion. Backoff is "skip this peer this round", eviction is "this node is dead".
+
+### File changes
+- `Comms.lua`: add `peerFailures` table, `MarkPeerFailure(key)`, `MarkPeerSuccess(key)`, `IsPeerBackedOff(key)` helpers; modify `HandleSyncRequest` responder selection and `OnSyncTimeout` retry logic to skip backed-off peers before escalating to eviction
+
+---
+
+## 6 — Offline Peer Replication
+
+**Priority: Low–Medium | Effort: High**
+
+**The core problem:** If the only guild member who has crafter X's data is offline when a new player joins, that data is simply unavailable until crafter X logs in. In large guilds where raiders play at varied times, this creates a permanently patchy database.
+
+**The solution:** Any online peer who *has* a copy of crafter X's data can serve it to a new requester on behalf of the offline owner. The data is clearly marked as `sourceType = "replica"` so the receiver knows it's a second-hand copy.
+
+### Design
+
+**Who can replicate?**
+Any addon user who has a stored entry for a member and that member is currently offline (not in `addonUsers`).
+
+**When does replication trigger?**
+- DR receives a `SYNC_REQUEST` from a new peer
+- DR checks which requested members are offline
+- For each offline member, DR nominates an online peer known to have that data (based on last SYNC_PUSH received) and sends them a `REPLICA_REQUEST` whisper
+- Nominated peer responds with the data in a `REPLICA_PUSH` — same chunked format as `SYNC_RESPONSE` but with an extra `replica = true` flag
+
+**Safety guards:**
+- Receiver must never write replica data that is *older* than what they already have for that member
+- Replica entries get a `replicatedAt` timestamp. They are used for display but treated as lower priority in any future merge conflict
+- A later direct sync from the actual owner always wins
+
+**Wire messages:**
+- `REPLICA_REQUEST` (DR → online peer, whisper): `{ memberKeys = { "X-Realm", "Y-Realm" } }`
+- `REPLICA_PUSH` (online peer → requester, whisper): same structure as `SYNC_RESPONSE` chunks with `replica = true`
+
+### File changes
+- `Comms.lua`: add `MSG_REPLICA_REQUEST`, `MSG_REPLICA_PUSH`, `HandleReplicaRequest`, `HandleReplicaPush`, logic in `ProcessSyncRequest` to identify offline members and nominate replicators
+- `Data.lua`: add `replica = true` flag handling in `MergeIncoming` — skip write if existing entry is newer; add `replicaSourceKey` field to stored entries for diagnostics
+- This is the largest change in this plan. Recommended to implement after items 1–4 are stable.
+
+---
+
+## Release Schedule
+
+Five patches over 4–5 weeks. Each patch is self-contained, testable in-game before the next one starts, and delivers visible value on its own.
+
+---
+
+### Patch 1 — Data Safety (Week 1)
+**Items: SyncPausePolicy + Partial Scan Protection**
+
+Pure additions. No protocol changes, no risk to existing sync. Ships as a single small release.
+
+- `SyncPausePolicy.lua` — suspend sync during combat, instances, zone transitions
+- Partial scan guard in `Data.lua` — 50% threshold, skip + reschedule
+
+Verification: enter combat, confirm no sync traffic in `/gc comms`. Open a profession window mid-load, confirm existing data is not wiped.
+
+---
+
+### Patch 2 — Faster Propagation (Week 2)
+**Item: AD Broadcast**
+
+First protocol change. New `DELTA_AD` message type. Old clients ignore unknown types so it is fully backwards compatible, but isolating it makes rollback clean if something unexpected happens.
+
+- `DELTA_AD` broadcast immediately after a scan detects changes
+- Peers queue a targeted pull on receipt
+
+Verification: scan a new recipe, confirm guildmates receive it within seconds rather than waiting for the next full sync cycle.
+
+---
+
+### Patch 3 — Reliable Transfers (Week 3)
+**Item: Chunk RESUME**
+
+Most invasive change to the existing sync path. Needs to stand alone so any regression in chunked transfer can be attributed unambiguously.
+
+- `sessionId` on all chunks
+- `partialReceive` tracking on the receiver
+- `SYNC_RESUME` message with missing seq list
+- 3-attempt cap before falling back to normal retry
+
+Verification: simulate chunk loss in a large guild (20+ members), confirm recovery happens in ~4s rather than 120s.
+
+---
+
+### Patch 4 — Smarter Failure Handling (Week 4)
+**Item: Per-Peer Backoff**
+
+Depends on Patch 3 being stable. Small change but touches timeout logic which has historically been subtle.
+
+- `peerFailures` table in `Comms`
+- `MarkPeerFailure` / `MarkPeerSuccess` / `IsPeerBackedOff` helpers
+- 45s backoff before escalating to DR eviction
+
+Verification: take the DR offline mid-sync, confirm it is bypassed cleanly rather than causing a full re-election storm.
+
+---
+
+### Patch 5 — Offline Replication (Week 5)
+**Item: Offline Peer Replication**
+
+Largest change. Ships last when the rest of the sync layer is proven stable under real guild conditions.
+
+- `REPLICA_REQUEST` / `REPLICA_PUSH` wire messages
+- DR nominates online peers to serve offline member data
+- `replica = true` flag in merge — direct owner data always wins
+
+Verification: have crafter X log off, have a new guild member join and sync — confirm X's recipes are visible immediately via replica, and that X's own next login overwrites with authoritative data.
+
+---
+
+## Out of Scope for v2
+
+- **AtlasLoot / TSM pricing integration** — requires significant UI changes and a separate data pipeline
+- **Manifest layer** — GuildCrafts' per-member timestamp model is simpler than per-block fingerprinting and sufficient for guild scale
+- **Bootstrap sync** — the existing DR → SYNC_REQUEST flow already handles first login correctly
+- **Performance scheduler** — GuildCrafts' scan/render workload is light enough that `AceTimer` debouncing is adequate


### PR DESCRIPTION
## Summary

Implements Patch 1 from the v2 implementation plan: two independent safety improvements that ship together as **v1.4.0**.

---

## Changes

### SyncPausePolicy (new module)

Suspends all outgoing sync traffic during high-activity game states where addon channel messages are most likely to be dropped or throttled.

| Condition | Grace after clearing |
|---|---|
| In combat (`InCombatLockdown`) | 6s after `PLAYER_REGEN_ENABLED` |
| Inside an instance (`IsInInstance`) | 15s after zone-in outside instance |
| Zone transition | 12s after `PLAYER_ENTERING_WORLD` |

- New file: `GuildCrafts/SyncPausePolicy.lua`
- 7 send sites guarded in `Comms.lua`: `SendMessage`, `SendChunked`, `BroadcastHello`, `SendSyncRequest`, `BroadcastNewRecipes`, `BroadcastProfessionRemoval`, `BroadcastTimestampTouch`
- `BroadcastHello` reschedules itself with deduplication (`_helloRescheduleTimer`) to prevent timer accumulation during a long pause
- `SendSyncRequest` sets `syncPending = true` while deferred to prevent duplicate sync chains
- `SendChunked` calls `onComplete` on suppress so the DR queue doesn't deadlock

### Partial Scan Protection

Prevents a partial or early-terminated profession scan from overwriting a complete stored entry. Guard compares total API-reported entry count (`numSkills` / `numCrafts`) against stored recipe count before the scan loop runs — if below 50%, aborts and reschedules 2s later.

- Pre-loop guard in `Data:ScanTradeSkill` (uses `numSkills`)
- Pre-loop guard in `Data:ScanCraft` (uses `numCrafts`)
- Per-profession guard in `Data:MergeIncoming` (blocks sync merges of suspiciously sparse incoming entries)
- `Data` module gains `AceTimer-3.0` mixin (required for `self:ScheduleTimer`)

---

## Version

`1.3.8` → **`1.4.0`** — bumped in `Core.lua` and `GuildCrafts.toc`.