### PR TITLE
feat: DELTA_AD broadcast + v1.5.0 (Patch 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.5.0 — 2026-05-15
+
+### New features
+
+- **Immediate advertise broadcast (`DELTA_AD`)** — when a profession scan finds new recipes, a tiny advertisement message is now broadcast to the guild immediately, carrying only a revision timestamp and per-profession recipe counts (no recipe data). Any peer who sees a `DELTA_AD` with a newer revision than what they already hold queues a sync pull with a short random jitter (1–5 s) to retrieve the data. This closes the propagation gap where a freshly scanned player's new recipes would not reach peers until the next full sync cycle. The Designated Router forwards received advertisements to the rest of the guild so nodes that missed the original broadcast are also notified.
+
+---
+
 ## 1.4.0 — 2026-05-15
 
 ### New features

--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -48,10 +48,15 @@ local PRIO_NORMAL = "NORMAL"
 local MSG_HELLO              = "HELLO"
 local MSG_HEARTBEAT          = "HEARTBEAT"
 local MSG_DELTA_UPDATE       = "DELTA_UPDATE"
+local MSG_DELTA_AD           = "DELTA_AD"
 local MSG_SYNC_REQUEST       = "SYNC_REQUEST"
 local MSG_SYNC_RESPONSE      = "SYNC_RESPONSE"
 local MSG_SYNC_PULL          = "SYNC_PULL"
 local MSG_SYNC_PUSH          = "SYNC_PUSH"
+
+-- AD: jitter range for targeted sync pull triggered by DELTA_AD receipt
+local AD_JITTER_MIN = 1
+local AD_JITTER_MAX = 5
 
 ----------------------------------------------------------------------
 -- State
@@ -907,6 +912,82 @@ function Comms:HandleDeltaUpdate(payload, sender)
     end
 end
 
+----------------------------------------------------------------------
+-- DELTA_AD  (lightweight "I have new data" advertisement)
+----------------------------------------------------------------------
+
+--- Broadcast a tiny advertisement after a local scan produces new recipes.
+--- Peers who are behind queue a targeted sync pull with jitter.
+--- Carries no recipe data — just a revision timestamp and per-profession counts.
+function Comms:BroadcastLocalAdvertise(memberKey, rev, profCounts)
+    if GuildCrafts.SyncPausePolicy and GuildCrafts.SyncPausePolicy:ShouldPause() then
+        GuildCrafts:Debug("BroadcastLocalAdvertise suppressed (SyncPausePolicy)")
+        return
+    end
+    if not IsInGuild() then return end
+    local playerKey = GuildCrafts.Data:GetPlayerKey()
+    self:SendMessage(MSG_DELTA_AD, {
+        sender     = playerKey,
+        memberKey  = memberKey,
+        rev        = rev,
+        profCounts = profCounts,
+    }, "GUILD", nil, PRIO_NORMAL)
+    GuildCrafts:Debug("Broadcast DELTA_AD for", memberKey, "rev", rev)
+end
+
+function Comms:HandleDeltaAd(payload, sender)
+    if not payload.memberKey or not payload.rev then return end
+
+    -- Register the sender in addonUsers so they appear in the DR election.
+    self:TouchAddonUser(sender)
+
+    local playerKey = GuildCrafts.Data:GetPlayerKey()
+    -- Ignore advertisements about ourselves.
+    if payload.memberKey == playerKey then return end
+
+    -- Check if the advertised revision is actually newer than what we hold.
+    local gdb = GuildCrafts.Data:GetGuildDB()
+    local localEntry = gdb and gdb[payload.memberKey]
+    local localTs = localEntry and localEntry.lastUpdate or 0
+    if payload.rev <= localTs then
+        GuildCrafts:Debug("DELTA_AD from", sender, "for", payload.memberKey, "— already current")
+        return
+    end
+
+    GuildCrafts:Debug("DELTA_AD from", sender, "for", payload.memberKey,
+        "rev", payload.rev, "— local", localTs)
+
+    -- DR forwards to guild so non-DR nodes that missed the original also get
+    -- the hint. The 'forwarded' flag prevents re-forwarding loops.
+    if self.myRole == "DR" and not payload.forwarded then
+        self:SendMessage(MSG_DELTA_AD, {
+            sender     = payload.sender or sender,
+            memberKey  = payload.memberKey,
+            rev        = payload.rev,
+            profCounts = payload.profCounts,
+            forwarded  = true,
+        }, "GUILD", nil, PRIO_NORMAL)
+        GuildCrafts:Debug("DR forwarded DELTA_AD for", payload.memberKey)
+        -- DR accumulates data through SYNC_PUSH; scheduling a sync pull via
+        -- SendSyncRequest would immediately no-op and could cancel a legitimate
+        -- pending timer from HELLO discovery. Return now.
+        return
+    end
+
+    -- Non-DR nodes queue a sync pull with jitter to avoid a thundering-herd burst.
+    if not self.syncPending then
+        local jitter = AD_JITTER_MIN + math.random() * (AD_JITTER_MAX - AD_JITTER_MIN)
+        if self._pendingSyncTimer then
+            self:CancelTimer(self._pendingSyncTimer)
+        end
+        self._pendingSyncTimer = self:ScheduleTimer(function()
+            self._pendingSyncTimer = nil
+            self:SendSyncRequest()
+        end, jitter)
+        GuildCrafts:Debug("DELTA_AD: queued sync pull in",
+            string.format("%.1fs", jitter))
+    end
+end
 
 ----------------------------------------------------------------------
 -- Message Send / Receive Infrastructure
@@ -1123,6 +1204,8 @@ function Comms:ProcessIncoming(message, _distribution, sender)
         self:HandleSyncPush(payload, sender)
     elseif msgType == MSG_DELTA_UPDATE then
         self:HandleDeltaUpdate(payload, sender)
+    elseif msgType == MSG_DELTA_AD then
+        self:HandleDeltaAd(payload, sender)
     else
         GuildCrafts:Debug("Unknown message type:", msgType, "from", sender)
     end

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.4.0"
+GuildCrafts.DISPLAY_VERSION = "1.5.0"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.
@@ -162,7 +162,8 @@ function GuildCrafts:OnLoginReady()
 end
 
 function GuildCrafts:OnTradeSkillShow()
-    -- Profession window was opened — scan recipes
+    -- Profession window was opened — scan recipes (DELTA_UPDATE + DELTA_AD
+    -- are broadcast from within ScanTradeSkill when new recipes are found)
     if self.Data then
         self.Data:ScanTradeSkill()
     end
@@ -170,6 +171,7 @@ end
 
 function GuildCrafts:OnCraftShow()
     -- Enchanting window was opened (Classic TBC uses separate Craft API)
+    -- DELTA_UPDATE + DELTA_AD are broadcast from within ScanCraft
     if self.Data then
         self.Data:ScanCraft()
     end

--- a/GuildCrafts/Data.lua
+++ b/GuildCrafts/Data.lua
@@ -989,6 +989,7 @@ function Data:ScanTradeSkill()
         GuildCrafts:Printf("Scanned %s: backfilled reagent/category data.", profName)
     end
 
+    local changed = newCount > 0
     if newCount > 0 then
         entry.lastUpdate = time()
         GuildCrafts:Printf("Scanned %s: %d new recipe(s) found.", profName, newCount)
@@ -996,6 +997,11 @@ function Data:ScanTradeSkill()
         -- Only broadcast the newly discovered recipes, not the entire set
         if GuildCrafts.Comms and GuildCrafts.Comms.BroadcastNewRecipes then
             GuildCrafts.Comms:BroadcastNewRecipes(playerKey, profName, newRecipes)
+        end
+        -- Advertise the new revision to peers who may have missed DELTA_UPDATE
+        if GuildCrafts.Comms and GuildCrafts.Comms.BroadcastLocalAdvertise then
+            GuildCrafts.Comms:BroadcastLocalAdvertise(
+                playerKey, entry.lastUpdate, self:GetPlayerProfCounts())
         end
 
         -- Invalidate tooltip index so new recipes appear in tooltips
@@ -1018,6 +1024,7 @@ function Data:ScanTradeSkill()
 
     -- Scan cooldowns while the window is open
     self:ScanTradeSkillCooldowns(profName, numSkills)
+    return changed
 end
 
 --- Get the recipe key (itemID or spellID) for a given trade skill index.
@@ -1189,12 +1196,18 @@ function Data:ScanCraft()
         GuildCrafts:Printf("Scanned %s: backfilled reagent/category data.", profName)
     end
 
+    local changed = newCount > 0
     if newCount > 0 then
         entry.lastUpdate = time()
         GuildCrafts:Printf("Scanned %s: %d new recipe(s) found.", profName, newCount)
 
         if GuildCrafts.Comms and GuildCrafts.Comms.BroadcastNewRecipes then
             GuildCrafts.Comms:BroadcastNewRecipes(playerKey, profName, newRecipes)
+        end
+        -- Advertise the new revision to peers who may have missed DELTA_UPDATE
+        if GuildCrafts.Comms and GuildCrafts.Comms.BroadcastLocalAdvertise then
+            GuildCrafts.Comms:BroadcastLocalAdvertise(
+                playerKey, entry.lastUpdate, self:GetPlayerProfCounts())
         end
 
         -- Invalidate tooltip index so new recipes appear in tooltips
@@ -1217,6 +1230,7 @@ function Data:ScanCraft()
 
     -- Scan cooldowns while the window is open
     self:ScanCraftCooldowns(profName, numCrafts)
+    return changed
 end
 
 function Data:GetCraftRecipeKey(index)
@@ -1329,6 +1343,21 @@ function Data:GetVersionVector()
         end
     end
     return vector
+end
+
+--- Return a table of { [profName] = recipeCount } for the local player.
+--- Used by BroadcastLocalAdvertise to populate the DELTA_AD profCounts field.
+function Data:GetPlayerProfCounts()
+    local playerKey = self:GetPlayerKey()
+    local entry = self:GetMemberEntry(playerKey, false)
+    if not entry or not entry.professions then return {} end
+    local counts = {}
+    for profName, profData in pairs(entry.professions) do
+        local count = 0
+        for _ in pairs(profData.recipes or {}) do count = count + 1 end
+        counts[profName] = count
+    end
+    return counts
 end
 
 ----------------------------------------------------------------------

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.4.0
+## Version: 1.5.0
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild


### PR DESCRIPTION
## Summary

Implements Patch 2 from `spec/implementation-plan-v2.md`: immediate lightweight advertisement broadcast after a local profession scan finds new recipes.

## What changed

### New: `DELTA_AD` message flow
- After a scan produces new recipes, a tiny advertisement (`memberKey`, `rev`, `profCounts`) is broadcast to the guild immediately — no recipe data, just a revision timestamp and per-profession counts.
- Any peer with an older revision queues a sync pull with 1–5s jitter to avoid thundering-herd bursts.
- The DR forwards received `DELTA_AD` messages to the guild (with `forwarded=true` to prevent loops) so nodes that missed the original broadcast are also notified.

### `Comms.lua`
- `MSG_DELTA_AD` constant
- `BroadcastLocalAdvertise(memberKey, rev, profCounts)` — SyncPausePolicy + IsInGuild guarded
- `HandleDeltaAd(payload, sender)` — DR-forward path + jittered sync pull for non-DR nodes
- Router entry for `MSG_DELTA_AD`

### `Data.lua`
- `BroadcastLocalAdvertise` called inside `ScanTradeSkill` and `ScanCraft` after new recipes are stored
- `GetPlayerProfCounts()` helper added alongside `GetVersionVector()`

### `Core.lua`
- `OnTradeSkillShow` / `OnCraftShow` simplified — broadcast now happens inside the scan functions

### Version
- Bumped to **1.5.0** in `GuildCrafts.toc`, `Core.lua`, and `CHANGELOG.md`

## Bug review (pre-merge)
Four issues found and fixed during review:
1. Missing `local changed` declaration in `ScanTradeSkill`
2. Broadcast moved inside scan functions so deferred rescans also trigger it
3. DR was scheduling `_pendingSyncTimer` after forwarding — fixed with early `return`
4. Duplicate `local changed = newCount > 0` — removed