### PR TITLE
feat: chunk RESUME recovery (Patch 3) + v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 1.6.0 — 2026-05-20
+## 1.6.0 — 2026-05-25
 
 ### New features
 
 - **Chunk RESUME recovery** — chunked `SYNC_RESPONSE` transfers are now resilient to dropped messages. The sender tags each transfer with a unique session ID and keeps a short-lived copy of every chunk for up to 35 seconds. If the receiver stops seeing new chunks for more than 4 seconds it whispers a `SYNC_RESUME` message back to the sender listing only the missing sequence numbers; the sender re-sends exactly those chunks. Recovery completes in roughly one `PROGRESS_TIMEOUT` (4 s) instead of waiting for the full 120 s `SYNC_TIMEOUT` before retrying the entire transfer. Up to three RESUME attempts are made before falling back to a full retry. Nodes running older versions of the addon are unaffected — transfers without a session ID continue to use the original code path.
+
+_Hat tip: Mattia (Kaedros) — [Recipe Registry](https://www.curseforge.com/wow/addons/recipe-registry)._
 
 ---
 
@@ -13,6 +15,8 @@
 ### New features
 
 - **Immediate advertise broadcast (`DELTA_AD`)** — when a profession scan finds new recipes, a tiny advertisement message is now broadcast to the guild immediately, carrying only a revision timestamp and per-profession recipe counts (no recipe data). Any peer who sees a `DELTA_AD` with a newer revision than what they already hold queues a sync pull with a short random jitter (1–5 s) to retrieve the data. This closes the propagation gap where a freshly scanned player's new recipes would not reach peers until the next full sync cycle. The Designated Router forwards received advertisements to the rest of the guild so nodes that missed the original broadcast are also notified.
+
+_Hat tip: Mattia (Kaedros) — [Recipe Registry](https://www.curseforge.com/wow/addons/recipe-registry)._
 
 ---
 
@@ -23,6 +27,8 @@
 - **SyncPausePolicy** — all outgoing sync traffic is now automatically suspended during combat, inside instances, and for a short grace period after zone transitions. This prevents addon messages from being dropped or contributing to chat throttle at exactly the moments when the client is busiest. Grace periods: 6 s after leaving combat, 12 s after a zone transition, 15 s after leaving an instance.
 
 - **Partial scan protection** — opening a profession window that the API hasn't fully loaded yet can return far fewer recipes than you actually know. The addon now compares the scanned count against the stored count before writing; if the new data accounts for less than 50 % of what's already recorded, the write is skipped and a rescan is scheduled 2 s later. The same guard is applied to incoming sync data, preventing a peer's partial scan from overwriting your complete local copy.
+
+_Hat tip: Mattia (Kaedros) — [Recipe Registry](https://www.curseforge.com/wow/addons/recipe-registry)._
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.6.0 — 2026-05-20
+
+### New features
+
+- **Chunk RESUME recovery** — chunked `SYNC_RESPONSE` transfers are now resilient to dropped messages. The sender tags each transfer with a unique session ID and keeps a short-lived copy of every chunk for up to 35 seconds. If the receiver stops seeing new chunks for more than 4 seconds it whispers a `SYNC_RESUME` message back to the sender listing only the missing sequence numbers; the sender re-sends exactly those chunks. Recovery completes in roughly one `PROGRESS_TIMEOUT` (4 s) instead of waiting for the full 120 s `SYNC_TIMEOUT` before retrying the entire transfer. Up to three RESUME attempts are made before falling back to a full retry. Nodes running older versions of the addon are unaffected — transfers without a session ID continue to use the original code path.
+
+---
+
 ## 1.5.0 — 2026-05-20
 
 ### New features

--- a/GuildCrafts/Comms.lua
+++ b/GuildCrafts/Comms.lua
@@ -53,6 +53,12 @@ local MSG_SYNC_REQUEST       = "SYNC_REQUEST"
 local MSG_SYNC_RESPONSE      = "SYNC_RESPONSE"
 local MSG_SYNC_PULL          = "SYNC_PULL"
 local MSG_SYNC_PUSH          = "SYNC_PUSH"
+local MSG_SYNC_RESUME        = "SYNC_RESUME"
+
+-- Chunk RESUME
+local PROGRESS_TIMEOUT     = 4    -- seconds without chunk progress before sending RESUME
+local SESSION_TTL          = 35   -- seconds to keep an outbound session for RESUME requests
+local MAX_RESUME_ATTEMPTS  = 3    -- max RESUME requests per transfer before falling back
 
 -- AD: jitter range for targeted sync pull triggered by DELTA_AD receipt
 local AD_JITTER_MIN = 1
@@ -96,6 +102,14 @@ function Comms:OnInitialize()
 
     -- BroadcastHello pause-reschedule timer (tracked so we never accumulate duplicates)
     self._helloRescheduleTimer = nil
+
+    -- Chunk RESUME: outbound sessions keyed by sessionId (sender side)
+    -- Each entry: { chunks = {[idx] = chunkPayload}, target = "Name-Realm" }
+    self._outboundSessions = {}
+
+    -- Chunk RESUME: partial receive state keyed by sessionId (receiver side)
+    -- Each entry: { seen = {[idx]=true}, total = N, resumeAttempts = N, sender, progressTimer }
+    self._partialReceive = {}
 
     -- Registered flag
     self._prefixRegistered = false
@@ -499,6 +513,9 @@ end
 function Comms:OnSyncTimeout()
     if not self.syncPending then return end
 
+    -- Clear any pending RESUME state — the full retry will start fresh.
+    self._partialReceive = {}
+
     self.syncRetryCount = self.syncRetryCount + 1
 
     if self.syncRetryCount == 1 then
@@ -681,13 +698,61 @@ function Comms:HandleSyncResponse(payload, sender)
     -- The node that responded is definitely online with the addon.
     self:TouchAddonUser(sender)
 
+    -- Merge this chunk's data immediately (each chunk contains distinct member keys).
     local merged = GuildCrafts.Data:MergeIncoming(payload.data)
     GuildCrafts:Debug("Received SYNC_RESPONSE chunk", (payload.chunkIndex or 1),
         "/", (payload.chunkTotal or 1), "from", sender, "— merged:", tostring(merged))
 
-    -- If more chunks expected, reset the sync timeout but stay pending
+    -- RESUME path: sender included a sessionId so we can recover dropped chunks.
+    local sessionId = payload.sessionId
+    if sessionId then
+        local pr = self._partialReceive[sessionId]
+        if not pr then
+            -- Guard: if sync is no longer pending (session already finalized), this
+            -- is a late/duplicate chunk arriving after we already completed the
+            -- transfer. Drop it to prevent recreating a stale _partialReceive entry
+            -- that would arm new progress timers and send spurious RESUME messages.
+            if not self.syncPending then return end
+            pr = {
+                seen           = {},
+                total          = payload.chunkTotal or 1,
+                resumeAttempts = 0,
+                sender         = sender,
+                progressTimer  = nil,
+            }
+            self._partialReceive[sessionId] = pr
+        end
+        -- Cancel existing progress timer — we just received a chunk.
+        if pr.progressTimer then
+            self:CancelTimer(pr.progressTimer)
+            pr.progressTimer = nil
+        end
+        pr.seen[payload.chunkIndex or 1] = true
+
+        -- Also reset the main sync timeout to give the RESUME process room to work.
+        if self.syncTimer then self:CancelTimer(self.syncTimer) end
+        self.syncTimer = self:ScheduleTimer("OnSyncTimeout", SYNC_TIMEOUT)
+
+        -- Count received chunks.
+        local receivedCount = 0
+        for _ in pairs(pr.seen) do receivedCount = receivedCount + 1 end
+
+        if receivedCount >= pr.total then
+            -- All chunks in — finalize.
+            self._partialReceive[sessionId] = nil
+            self:_FinalizeSyncResponse()
+        else
+            -- More chunks expected — arm the progress timeout.
+            pr.progressTimer = self:ScheduleTimer(function()
+                self:_OnProgressTimeout(sessionId)
+            end, PROGRESS_TIMEOUT)
+        end
+        return
+    end
+
+    -- Legacy path (sender pre-dates Patch 3, no sessionId): original behaviour.
     if payload.chunkIndex and payload.chunkTotal and payload.chunkIndex < payload.chunkTotal then
-        -- Reset timeout — more chunks coming
+        -- Reset timeout — more chunks coming.
         if self.syncTimer then
             self:CancelTimer(self.syncTimer)
         end
@@ -695,7 +760,12 @@ function Comms:HandleSyncResponse(payload, sender)
         return
     end
 
-    -- All chunks received (or single un-chunked response) — sync complete
+    -- Single chunk or last chunk of a legacy multi-chunk transfer — finalize.
+    self:_FinalizeSyncResponse()
+end
+
+--- Shared finalization for both RESUME and legacy sync completion.
+function Comms:_FinalizeSyncResponse()
     self.syncPending         = false
     self.syncRetryCount      = 0
     self.lastSyncCompletedAt = time()
@@ -716,6 +786,75 @@ function Comms:HandleSyncResponse(payload, sender)
     if not self._postSyncHelloDone then
         self._postSyncHelloDone = true
         self:ScheduleTimer("BroadcastPostSyncHello", 5)
+    end
+end
+
+--- Called when no chunk progress is seen within PROGRESS_TIMEOUT seconds.
+--- Sends a SYNC_RESUME whisper listing missing sequence numbers.
+function Comms:_OnProgressTimeout(sessionId)
+    local pr = self._partialReceive[sessionId]
+    if not pr then return end
+
+    -- Race: check if all chunks arrived between timer scheduling and firing.
+    local receivedCount = 0
+    for _ in pairs(pr.seen) do receivedCount = receivedCount + 1 end
+    if receivedCount >= pr.total then
+        self._partialReceive[sessionId] = nil
+        self:_FinalizeSyncResponse()
+        return
+    end
+
+    if pr.resumeAttempts >= MAX_RESUME_ATTEMPTS then
+        GuildCrafts:Debug("RESUME: max attempts reached for session", sessionId,
+            "— falling back to full retry")
+        self._partialReceive[sessionId] = nil
+        -- Main syncTimer (SYNC_TIMEOUT) will fire and call OnSyncTimeout.
+        return
+    end
+
+    -- Build the missing seq list.
+    local missing = {}
+    for i = 1, pr.total do
+        if not pr.seen[i] then
+            missing[#missing + 1] = i
+        end
+    end
+
+    pr.resumeAttempts = pr.resumeAttempts + 1
+    GuildCrafts:Debug("RESUME: requesting", #missing, "chunk(s) for session", sessionId,
+        "(attempt", pr.resumeAttempts, "/", MAX_RESUME_ATTEMPTS, ")")
+
+    self:SendMessage(MSG_SYNC_RESUME, {
+        sessionId = sessionId,
+        missing   = missing,
+    }, "WHISPER", pr.sender, PRIO_NORMAL)
+
+    -- Restart the progress timer for this attempt.
+    pr.progressTimer = self:ScheduleTimer(function()
+        self:_OnProgressTimeout(sessionId)
+    end, PROGRESS_TIMEOUT)
+end
+
+--- Received by the sender when the requester reports missing chunks.
+function Comms:HandleSyncResume(payload, sender)
+    if not payload.sessionId or not payload.missing or #payload.missing == 0 then return end
+
+    local session = self._outboundSessions[payload.sessionId]
+    if not session then
+        GuildCrafts:Debug("RESUME: session", payload.sessionId, "not found (expired) — requester will retry on timeout")
+        return
+    end
+
+    -- Always reply to the original requester (session.target), not the message
+    -- sender. For legitimate traffic they match, but using session.target ensures
+    -- a spoofed SYNC_RESUME can't redirect chunks to an unintended recipient.
+    GuildCrafts:Debug("RESUME: resending", #payload.missing, "chunk(s) for session",
+        payload.sessionId, "to", session.target)
+    for _, seqNum in ipairs(payload.missing) do
+        local chunkPayload = session.chunks[seqNum]
+        if chunkPayload then
+            self:SendMessage(MSG_SYNC_RESPONSE, chunkPayload, "WHISPER", session.target, PRIO_BULK)
+        end
     end
 end
 
@@ -1013,6 +1152,10 @@ function Comms:SendChunked(msgType, memberData, target, totalCount, onComplete)
 
     local totalChunks = math.ceil(totalCount / SYNC_CHUNK_SIZE)
 
+    -- Generate a unique session ID so the receiver can request missing chunks.
+    local sessionId = string.format("%s:%d:%04d", target, time(), math.random(1000, 9999))
+    self._outboundSessions[sessionId] = { chunks = {}, target = target }
+
     local function sendChunk(chunkIndex, startIdx)
         if startIdx > #keys then return end
 
@@ -1021,11 +1164,16 @@ function Comms:SendChunked(msgType, memberData, target, totalCount, onComplete)
             chunk[keys[j]] = memberData[keys[j]]
         end
 
-        self:SendMessage(msgType, {
+        local chunkPayload = {
             data       = chunk,
             chunkIndex = chunkIndex,
             chunkTotal = totalChunks,
-        }, "WHISPER", target, PRIO_BULK)
+            sessionId  = sessionId,
+        }
+        -- Keep a copy for potential RESUME re-sends.
+        self._outboundSessions[sessionId].chunks[chunkIndex] = chunkPayload
+
+        self:SendMessage(msgType, chunkPayload, "WHISPER", target, PRIO_BULK)
 
         GuildCrafts:Debug("Sent chunk", chunkIndex, "/", totalChunks, "to", target)
 
@@ -1034,9 +1182,15 @@ function Comms:SendChunked(msgType, memberData, target, totalCount, onComplete)
             self:ScheduleTimer(function()
                 sendChunk(chunkIndex + 1, nextStart)
             end, SYNC_CHUNK_DELAY)
-        elseif onComplete then
-            -- Last chunk sent — notify caller
-            onComplete()
+        else
+            -- Last chunk sent — expire session after TTL and notify caller.
+            self:ScheduleTimer(function()
+                self._outboundSessions[sessionId] = nil
+                GuildCrafts:Debug("RESUME: outbound session expired:", sessionId)
+            end, SESSION_TTL)
+            if onComplete then
+                onComplete()
+            end
         end
     end
 
@@ -1206,6 +1360,8 @@ function Comms:ProcessIncoming(message, _distribution, sender)
         self:HandleDeltaUpdate(payload, sender)
     elseif msgType == MSG_DELTA_AD then
         self:HandleDeltaAd(payload, sender)
+    elseif msgType == MSG_SYNC_RESUME then
+        self:HandleSyncResume(payload, sender)
     else
         GuildCrafts:Debug("Unknown message type:", msgType, "from", sender)
     end

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.5.0"
+GuildCrafts.DISPLAY_VERSION = "1.6.0"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.5.0
+## Version: 1.6.0
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild


### PR DESCRIPTION
## Patch 3 — Chunk RESUME / Recovery

Chunked `SYNC_RESPONSE` transfers are now resilient to dropped messages.

### What changed
- Sender tags each transfer with a unique `sessionId` and keeps a short-lived copy of every chunk for 35 seconds (`_outboundSessions`)
- Receiver tracks received chunk indices in `_partialReceive[sessionId]`
- If no new chunk arrives within 4 seconds (`PROGRESS_TIMEOUT`), receiver whispers a `SYNC_RESUME` message listing only the missing sequence numbers
- Sender resends exactly those chunks from the session cache
- Up to 3 RESUME attempts before falling back to the normal 120s timeout/retry path
- Nodes on older versions are unaffected — transfers without a `sessionId` continue to use the original code path

### Edge cases reviewed
- Progress timers from a cleared `_partialReceive` (after `OnSyncTimeout`) fire harmlessly (pr = nil → return)
- `_FinalizeSyncResponse` is idempotent — safe if called twice in the retry=1 double-response case
- `HandleSyncResume` always replies to `session.target`, not the message sender (prevents redirect)

Bumps version to **1.6.0**.