### PR TITLE
fix: !gc spam when election hasn't converged (v1.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.10.0 — 2026-06-23
+
+### Fixes
+
+- **`!gc` spam — all addon users responding simultaneously** — when the DR/BDR election had not yet converged (e.g. start of a raid session, mass login, or reconnect), every online addon user computed `myRole = "DR"` and scheduled their `!gc` response at `delay = 0`. All responses fired in the same WoW frame before any guild-chat echo could arrive to trigger the deduplication check, causing every addon user to post a reply simultaneously. Fixed by detecting the unconverged state (`addonUsers` contains only self) and applying a 2–6 s random jitter in that case. The first node to fire sends `[GuildCrafts]` to guild chat; its echo updates `_gcLastGuildCraftsMsg` on all other clients, and their later-firing timers see the timestamp and cancel. When the election is properly converged, the real DR keeps `delay = 0` for an immediate response — no regression for normal operation.
+
+---
+
 ## 1.9.0 — 2026-06-08
 
 ### Fixes

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.9.0"
+GuildCrafts.DISPLAY_VERSION = "1.10.0"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.
@@ -353,6 +353,21 @@ function GuildCrafts:OnGuildChatMessage(_event, msg)
         -- time. The first to post emits [GuildCrafts] in guild chat, causing
         -- all others to cancel when their timer fires.
         delay = 12 + math.random(0, 8)
+    elseif effectiveRole == "DR" then
+        -- Guard against "false DR" spam: when the election has not yet converged
+        -- (addonUsers contains only self — HELLO messages not yet exchanged,
+        -- fresh session, or entries evicted), every node computes myRole = "DR"
+        -- and fires at delay = 0 simultaneously.  All responses go out in the
+        -- same frame before any guild-chat echo can update _gcLastGuildCraftsMsg
+        -- and trigger the dedup check on the other nodes.
+        -- Fix: apply jitter so the first responder's echo suppresses the rest.
+        -- When the election is properly converged (addonUsers has multiple
+        -- entries) the real DR keeps delay = 0 for an immediate response.
+        local count = 0
+        for _ in pairs(self.Comms.addonUsers) do count = count + 1 end
+        if count <= 1 then
+            delay = 2 + math.random(0, 4)  -- 2–6 s jitter for unconverged election
+        end
     end
 
     local capturedQuery      = query

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.9.0
+## Version: 1.10.0
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild


### PR DESCRIPTION
## Problem

When the DR/BDR election has not yet converged — e.g. start of a raid session, mass login, or reconnect — every online addon user computes `myRole = "DR"` (each node only knows about itself in `addonUsers`). All nodes schedule their `!gc` response at `delay = 0`, firing in the same WoW frame before any guild-chat echo can update `_gcLastGuildCraftsMsg` and trigger the deduplication check. Result: every addon user posts a reply simultaneously.

## Fix

Added an `elseif effectiveRole == "DR"` branch that detects the unconverged state (`addonUsers` count ≤ 1) and applies a 2–6 s random jitter. The first node to fire sends `[GuildCrafts]`; its echo suppresses all later-firing nodes via the existing timestamp check. When the election is properly converged the real DR keeps `delay = 0` — no regression.