### PR TITLE
fix: TBC 2.5.6 tooltip compat guard (TooltipDataProcessor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.10.1 — 2026-07-20
+
+### Fixes
+
+- **Tooltip crafter rows compatible with TBC Anniversary 2.5.6 PTR** — the 2.5.6 client introduces the modern tooltip pipeline (`TooltipDataProcessor`), which replaces the old `OnTooltipSetItem` script event. GuildCrafts now detects which pipeline is available and uses `TooltipDataProcessor.AddTooltipPostCall` on 2.5.6+ while keeping the legacy hook on the current 2.5.5 live client. No tooltip breakage on either client.
+
+---
+
 ## 1.10.0 — 2026-06-23
 
 ### Fixes

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.10.0"
+GuildCrafts.DISPLAY_VERSION = "1.10.1"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -2,7 +2,7 @@
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.10.0
+## Version: 1.10.1
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild

--- a/GuildCrafts/Tooltip.lua
+++ b/GuildCrafts/Tooltip.lua
@@ -103,12 +103,19 @@ end
 ----------------------------------------------------------------------
 
 function Tooltip:OnEnable()
-    -- Hook GameTooltip's OnTooltipSetItem to inject crafter info
-    self:SecureHookScript(GameTooltip, "OnTooltipSetItem", "OnTooltipSetItem")
-
-    -- Also hook ItemRefTooltip (shift-clicked links in chat)
-    if ItemRefTooltip then
-        self:SecureHookScript(ItemRefTooltip, "OnTooltipSetItem", "OnTooltipSetItem")
+    if TooltipDataProcessor then
+        -- 2.5.6+ modern tooltip pipeline (aligned with Classic Era 1.15.9).
+        -- AddTooltipPostCall fires for all tooltips showing items, including
+        -- ItemRefTooltip, so no separate hook is needed.
+        TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, function(tooltip, data)
+            self:OnTooltipSetItem(tooltip)
+        end)
+    else
+        -- Legacy path: 2.5.5 and earlier.
+        self:SecureHookScript(GameTooltip, "OnTooltipSetItem", "OnTooltipSetItem")
+        if ItemRefTooltip then
+            self:SecureHookScript(ItemRefTooltip, "OnTooltipSetItem", "OnTooltipSetItem")
+        end
     end
 
     -- Rebuild on enable. RebuildIndex will defer automatically if the client


### PR DESCRIPTION
## Summary

TBC Anniversary 2.5.6 (currently on PTR) moves to the modern addon API aligned with Classic Era 1.15.9. The modern tooltip pipeline uses `TooltipDataProcessor` and the old `OnTooltipSetItem` script event no longer fires.

## Changes

- **Tooltip.lua** — `OnEnable` now checks for `TooltipDataProcessor` at runtime:
  - **2.5.6+**: registers via `TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, ...)` — covers both `GameTooltip` and `ItemRefTooltip` automatically
  - **2.5.5 live**: falls back to the existing `SecureHookScript` path — no regression
- **Version**: 1.10.0 → 1.10.1
- **Interface**: stays at 20505 until 2.5.6 ships to live

## Why now

A competing addon shipped the `TooltipDataProcessor` migration without a compat guard, breaking crafter tooltips for all live 2.5.5 users overnight and requiring an emergency hotfix the same day. This fix handles both clients in a single release.