### PR TITLE
feat: shift-click recipe name to link to chat (v1.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### New features
 
-- **Shift-click a recipe name to link it to chat** — shift-clicking any recipe name in the member detail, recipes, favorites, or search results view inserts the item or spell hyperlink directly into the active chat input, exactly like shift-clicking items in bags or tooltips. Works for all professions including Enchanting (spell links).
+- **Shift-click a recipe name to link it to chat** — shift-clicking any recipe name in the member detail, recipes, favorites, or search results view inserts the item or spell hyperlink directly into the active chat input, exactly like shift-clicking items in bags or tooltips. Works for all professions including Enchanting (spell links). (Thanks to Cha0sx for the inspiration.)
 
 ### Changes
 
-- **Interface version bumped to 20506** — TBC Anniversary 2.5.6 is now live. The tooltip crafter pipeline introduced in 1.10.1 (`TooltipDataProcessor` guard) continues to work correctly on the new client.
+- **Interface version bumped to 20506** — TBC Anniversary 2.5.6 is live. The tooltip crafter pipeline introduced in 1.10.1 (`TooltipDataProcessor` guard) continues to work correctly on the new client.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.11.0 — 2026-07-21
+
+### New features
+
+- **Shift-click a recipe name to link it to chat** — shift-clicking any recipe name in the member detail, recipes, favorites, or search results view inserts the item or spell hyperlink directly into the active chat input, exactly like shift-clicking items in bags or tooltips. Works for all professions including Enchanting (spell links).
+
+### Changes
+
+- **Interface version bumped to 20506** — TBC Anniversary 2.5.6 is now live. The tooltip crafter pipeline introduced in 1.10.1 (`TooltipDataProcessor` guard) continues to work correctly on the new client.
+
+---
+
 ## 1.10.1 — 2026-07-20
 
 ### Fixes

--- a/GuildCrafts/Core.lua
+++ b/GuildCrafts/Core.lua
@@ -16,7 +16,7 @@ local GuildCrafts = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME,
 _G.GuildCrafts = GuildCrafts
 
 -- Addon version — keep in sync with .toc and CurseForge
-GuildCrafts.DISPLAY_VERSION = "1.10.1"
+GuildCrafts.DISPLAY_VERSION = "1.11.0"
 
 -- Protocol version — integer used in sync envelope for compatibility checks.
 -- Bump when the wire format changes in a backward-incompatible way.

--- a/GuildCrafts/GuildCrafts.toc
+++ b/GuildCrafts/GuildCrafts.toc
@@ -1,8 +1,8 @@
-## Interface: 20505
+## Interface: 20506
 ## Title: GuildCrafts
 ## Notes: Track all learned recipes across guild members' professions
 ## Author: GuildCrafts Team
-## Version: 1.10.1
+## Version: 1.11.0
 ## SavedVariables: GuildCraftsDB
 ## SavedVariablesPerCharacter: GuildCraftsCharDB
 ## X-Category: Guild

--- a/GuildCrafts/UI/MainFrame.lua
+++ b/GuildCrafts/UI/MainFrame.lua
@@ -1074,6 +1074,11 @@ function UI:ShowMemberRecipes(memberKey, profName)
             UI:ShowRecipeTooltip(self, capturedKey)
         end)
         nameHit:SetScript("OnLeave", function() GameTooltip:Hide() end)
+        nameHit:SetScript("OnMouseDown", function(_, button)
+            if button == "LeftButton" and IsShiftKeyDown() then
+                UI:LinkRecipeToChat(capturedKey)
+            end
+        end)
 
         -- Click recipe row to toggle reagents (only when has reagents)
         if hasReagents then
@@ -1250,6 +1255,11 @@ function UI:ShowSearchResults(results)
             UI:ShowRecipeTooltip(self, capturedRecipeKey)
         end)
         nameHit:SetScript("OnLeave", function() GameTooltip:Hide() end)
+        nameHit:SetScript("OnMouseDown", function(_, button)
+            if button == "LeftButton" and IsShiftKeyDown() then
+                UI:LinkRecipeToChat(capturedRecipeKey)
+            end
+        end)
 
         -- Inline crafter preview (right section, max 2 + overflow count)
         table.sort(result.crafters, function(a, b)
@@ -1740,6 +1750,11 @@ function UI:ShowFavRecipesDetail(grouped, filterProf)
                 UI:ShowRecipeTooltip(self, capturedKey)
             end)
             nameHit:SetScript("OnLeave", function() GameTooltip:Hide() end)
+            nameHit:SetScript("OnMouseDown", function(_, button)
+                if button == "LeftButton" and IsShiftKeyDown() then
+                    UI:LinkRecipeToChat(capturedKey)
+                end
+            end)
             yOffset = yOffset - 18
 
             -- Crafters list
@@ -2310,6 +2325,25 @@ end
 
 --- Show the native WoW item or spell tooltip for a recipe key.
 --- Positive key = itemID, negative key = spellID (Enchanting / spell-based).
+--- Shift-click a recipe name to insert its item or spell link into the active chat input.
+function UI:LinkRecipeToChat(recipeKey)
+    local k = tonumber(recipeKey)
+    if not k then return end
+    local link
+    if k > 0 then
+        link = select(2, GetItemInfo(k))
+    elseif k < 0 then
+        if C_Spell and C_Spell.GetSpellLink then
+            link = C_Spell.GetSpellLink(-k)
+        elseif GetSpellLink then
+            link = GetSpellLink(-k)
+        end
+    end
+    if link then
+        ChatEdit_InsertLink(link)
+    end
+end
+
 function UI:ShowRecipeTooltip(owner, recipeKey)
     local k = tonumber(recipeKey)
     if not k then return end
@@ -2735,6 +2769,11 @@ function UI:ShowRecipesView(profName)
             UI:ShowRecipeTooltip(self, capturedNameKey)
         end)
         nameHit:SetScript("OnLeave", function() GameTooltip:Hide() end)
+        nameHit:SetScript("OnMouseDown", function(_, button)
+            if button == "LeftButton" and IsShiftKeyDown() then
+                UI:LinkRecipeToChat(capturedNameKey)
+            end
+        end)
 
         -- Sort crafters: self first, then online, then alphabetical
         table.sort(recipe.crafters, function(a, b)


### PR DESCRIPTION
## Summary

Two changes in one release:

### New feature: shift-click to link
Shift-clicking any recipe name inserts its hyperlink into the active chat input — the same muscle memory as shift-clicking items in bags, tooltips, or the AH. Covers all four views (member detail, recipes, favorites, search results). Enchanting recipes use spell links; everything else uses item links. Thanks to Cha0sx for the inspiration.

### Interface 20505 → 20506
TBC Anniversary 2.5.6 shipped to live. The `TooltipDataProcessor` guard from 1.10.1 is confirmed working correctly on the new client — no further changes needed.